### PR TITLE
Add from __future__ import annotations

### DIFF
--- a/custom_components/ramses_cc/__init__.py
+++ b/custom_components/ramses_cc/__init__.py
@@ -5,6 +5,7 @@
 
 Requires a Honeywell HGI80 (or compatible) gateway.
 """
+from __future__ import annotations
 
 import asyncio
 import logging

--- a/custom_components/ramses_cc/binary_sensor.py
+++ b/custom_components/ramses_cc/binary_sensor.py
@@ -5,6 +5,7 @@
 
 Provides support for binary sensors.
 """
+from __future__ import annotations
 
 import logging
 from datetime import datetime as dt

--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -5,6 +5,7 @@
 
 Provides support for climate entities.
 """
+from __future__ import annotations
 
 import logging
 

--- a/custom_components/ramses_cc/climate_heat.py
+++ b/custom_components/ramses_cc/climate_heat.py
@@ -5,6 +5,7 @@
 
 Provides support for climate entities.
 """
+from __future__ import annotations
 
 import logging
 from datetime import datetime as dt

--- a/custom_components/ramses_cc/const.py
+++ b/custom_components/ramses_cc/const.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 """Support for Honeywell's RAMSES-II RF protocol, as used by CH/DHW & HVAC."""
+from __future__ import annotations
 
 from types import SimpleNamespace
 

--- a/custom_components/ramses_cc/helpers.py
+++ b/custom_components/ramses_cc/helpers.py
@@ -5,6 +5,7 @@
 
 Requires a Honeywell HGI80 (or compatible) gateway.
 """
+from __future__ import annotations
 
 import logging
 

--- a/custom_components/ramses_cc/remote.py
+++ b/custom_components/ramses_cc/remote.py
@@ -5,6 +5,7 @@
 
 Provides support for HVAC RF remotes.
 """
+from __future__ import annotations
 
 import asyncio
 import logging

--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 """Support for Honeywell's RAMSES-II RF protocol, as used by CH/DHW & HVAC."""
+from __future__ import annotations
 
 import logging
 from copy import deepcopy

--- a/custom_components/ramses_cc/sensor.py
+++ b/custom_components/ramses_cc/sensor.py
@@ -5,6 +5,7 @@
 
 Provides support for sensors.
 """
+from __future__ import annotations
 
 import logging
 from typing import Any

--- a/custom_components/ramses_cc/test_schema.py
+++ b/custom_components/ramses_cc/test_schema.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 """Support for Honeywell's RAMSES-II RF protocol, as used by CH/DHW & HVAC."""
+from __future__ import annotations
 
 import logging
 

--- a/custom_components/ramses_cc/water_heater.py
+++ b/custom_components/ramses_cc/water_heater.py
@@ -5,6 +5,7 @@
 
 Provides support for water_heater entities.
 """
+from __future__ import annotations
 
 import logging
 from datetime import datetime as dt


### PR DESCRIPTION
As requested in forum.
This should fix annotation errors for python <3.10.