### PR TITLE
Update __init__.py

### DIFF
--- a/custom_components/ramses_cc/__init__.py
+++ b/custom_components/ramses_cc/__init__.py
@@ -140,7 +140,7 @@ def register_domain_services(hass: HomeAssistantType, broker: RamsesBroker):
             and kwargs.get("from_id", "18:000730") == "18:000730"
             and broker.client.hgi.id
         ):
-            kwargs["device_id"] = broker.client.hgi.id
+            kwargs["device_id"] = kwargs["from_id"] = broker.client.hgi.id
         broker.client.send_cmd(broker.client.create_cmd(**kwargs))
         hass.helpers.event.async_call_later(5, broker.async_update)
 


### PR DESCRIPTION
This reverses commit c375718 which is described as a bugfix regression for the send_packet service.

I'm not sure what the original bug that this regressed to fixed, but with it reversed, the send_packet service works again.

Have successfully tested by binding a relay as described in the wiki and using the appropriate commands in HA and the example automation to turn the relay off/on.