### PR TITLE
Correct manifest version and remove version constant

### DIFF
--- a/custom_components/ramses_cc/__init__.py
+++ b/custom_components/ramses_cc/__init__.py
@@ -34,7 +34,6 @@ from .schemas import (
     SZ_ADVANCED_FEATURES,
     SZ_MESSAGE_EVENTS,
 )
-from .version import __version__ as VERSION
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -52,12 +51,6 @@ PLATFORMS = [
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Create a ramses_rf (RAMSES_II)-based system."""
 
-    _LOGGER.info(
-        "%s v%s, is using ramses_rf v%s",
-        DOMAIN,
-        VERSION,
-        ramses_rf.VERSION,
-    )
     _LOGGER.debug("\r\n\nConfig = %s\r\n", config[DOMAIN])
 
     coordinator: DataUpdateCoordinator = DataUpdateCoordinator(

--- a/custom_components/ramses_cc/manifest.json
+++ b/custom_components/ramses_cc/manifest.json
@@ -9,5 +9,5 @@
     "dependencies": [],
     "issue_tracker": "https://github.com/zxdavb/ramses_cc/issues",
     "codeowners": ["@zxdavb"],
-    "version": "0.0.2"
+    "version": "0.30.4"
   }

--- a/custom_components/ramses_cc/version.py
+++ b/custom_components/ramses_cc/version.py
@@ -1,2 +1,0 @@
-"""RAMSES integration version."""
-__version__ = "0.30.0"


### PR DESCRIPTION
This also removes the info log about versions on startup, but it didn't seem like that was a huge loss as:
- It's not something I've seen other components do
- Anyone installing from HACS can check the installed version there
- Anyone installing manually can check the manifest