### PR TITLE
Add remote to list of platforms

### DIFF
--- a/custom_components/ramses_cc/__init__.py
+++ b/custom_components/ramses_cc/__init__.py
@@ -45,6 +45,7 @@ PLATFORMS = [
     Platform.BINARY_SENSOR,
     Platform.CLIMATE,
     Platform.SENSOR,
+    Platform.REMOTE,
     Platform.WATER_HEATER,
 ]
 


### PR DESCRIPTION
This isn't used at present but will come into play later when we forward config entries to each of the platforms.