### PR TITLE
Fix system mode period/duration args

### DIFF
--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -277,12 +277,12 @@ class RamsesController(RamsesZoneBase, ClimateEntity):
         self._call_client_api(self._device.reset_mode)
 
     @callback
-    def svc_set_system_mode(self, mode, period=None, days=None) -> None:
+    def svc_set_system_mode(self, mode, period=None, duration=None) -> None:
         """Set the (native) operating mode of the Controller."""
         if period is not None:
-            until = dt.now() + period
-        elif days is not None:
-            until = dt.now() + days  # TODO: round down
+            until = dt.now() + period  # Period in days TODO: round down
+        elif duration is not None:
+            until = dt.now() + duration  # Duration in hours/minutes for eco_boost
         else:
             until = None
         self._call_client_api(self._device.set_mode, system_mode=mode, until=until)


### PR DESCRIPTION
I believe this is the intended behaviour based on [services.yaml](https://github.com/zxdavb/ramses_cc/blob/7fcf48ae23a7c5073addbfd25fd606c061ef3457/custom_components/ramses_cc/services.yaml#L150).

The naming of the arguments seems a bit odd to me, so perhaps a future candidate for deprecation/renaming? 