### PR TITLE
Tidy up broker

### DIFF
--- a/custom_components/ramses_cc/binary_sensor.py
+++ b/custom_components/ramses_cc/binary_sensor.py
@@ -27,8 +27,8 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import RamsesSensorBase
+from .broker import RamsesBroker
 from .const import ATTR_BATTERY_LEVEL, BROKER, DOMAIN
-from .coordinator import RamsesBroker
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -35,6 +35,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import RamsesEntity
+from .broker import RamsesBroker
 from .const import (
     ATTR_DURATION,
     ATTR_LOCAL_OVERRIDE,
@@ -65,7 +66,6 @@ from .const import (
     SystemMode,
     ZoneMode,
 )
-from .coordinator import RamsesBroker
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/ramses_cc/remote.py
+++ b/custom_components/ramses_cc/remote.py
@@ -23,6 +23,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import DiscoveryInfoType
 
 from . import RamsesEntity
+from .broker import RamsesBroker
 from .const import (
     ATTR_COMMAND,
     ATTR_DELAY_SECS,
@@ -34,7 +35,6 @@ from .const import (
     SVC_LEARN_COMMAND,
     SVC_SEND_COMMAND,
 )
-from .coordinator import RamsesBroker
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -149,7 +149,7 @@ def merge_schemas(config_schema: _SchemaT, cached_schema: _SchemaT) -> _SchemaT 
         _LOGGER.info("Using the cached schema")
         return cached_schema
 
-    merged_schema = deep_merge(config_schema, cached_schema)  # 1st takes precidence
+    merged_schema = deep_merge(config_schema, cached_schema)  # 1st takes precedence
 
     if _is_subset(shrink(config_schema), shrink(merged_schema)):
         _LOGGER.info("Using a merged schema")

--- a/custom_components/ramses_cc/sensor.py
+++ b/custom_components/ramses_cc/sensor.py
@@ -61,6 +61,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import RamsesSensorBase
+from .broker import RamsesBroker
 from .const import (
     ATTR_CO2_LEVEL,
     ATTR_INDOOR_HUMIDITY,
@@ -71,7 +72,6 @@ from .const import (
     SVC_PUT_INDOOR_HUMIDITY,
     UnitOfVolumeFlowRate,
 )
-from .coordinator import RamsesBroker
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/ramses_cc/water_heater.py
+++ b/custom_components/ramses_cc/water_heater.py
@@ -25,6 +25,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import RamsesEntity
+from .broker import RamsesBroker
 from .const import (
     ATTR_ACTIVE,
     ATTR_DIFFERENTIAL,
@@ -48,7 +49,6 @@ from .const import (
     SystemMode,
     ZoneMode,
 )
-from .coordinator import RamsesBroker
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
Tidies up broker start and polling.

Removes redundant DataUpdateCoordinator as the broker already handles updates on an interval. This is more suited to a single API call that returns data and is intended for use with entities that extend `CoordinatorEntity`. Without such entities in place there are no listeners registered with the coordinator and it never does any polling. It seems like a better idea to stick with the existing broker setup as ideally in future it would be possible to transition to listening to event-based updates from ramses_rf which the DataUpdateCoordinator framework is not suited to.