### PR TITLE
Improve active_fault binary sensor state

### DIFF
--- a/custom_components/ramses_cc/binary_sensor.py
+++ b/custom_components/ramses_cc/binary_sensor.py
@@ -160,10 +160,9 @@ class RamsesLogbookBinarySensor(RamsesBinarySensor):
         return msg and dt.now() - msg.dtm < timedelta(seconds=1200)
 
     @property
-    def is_on(self) -> bool | None:
+    def is_on(self) -> bool:
         """Return the state of the binary sensor."""
-        result = getattr(self._device, self.entity_description.attr)
-        return None if result is None else bool(result)
+        return self._device.active_fault is not None
 
 
 class RamsesSystemBinarySensor(RamsesBinarySensor):


### PR DESCRIPTION
As we have a separate available check here then we should always be returning whether or not there is an active fault.