### PR TITLE
Minor lint/const cleanup in broker

### DIFF
--- a/custom_components/ramses_cc/const.py
+++ b/custom_components/ramses_cc/const.py
@@ -22,6 +22,11 @@ CONF_RAMSES_RF = "ramses_rf"
 CONF_SEND_PACKET = "send_packet"
 CONF_UNKNOWN_CODES = "unknown_codes"
 
+# State
+SZ_CLIENT_STATE = "client_state"
+SZ_PACKETS = "packets"
+SZ_REMOTES = "remotes"
+
 # Entity/service attributes
 ATTR_ACTIVE = "active"
 ATTR_ACTIVE_FAULT = "active_fault"


### PR DESCRIPTION
The config flow changes operate on the state to clear the cache elsewhere so it made sense to move those out into const now.