### PR TITLE
Move all service schemas to schemas.py

### DIFF
--- a/custom_components/ramses_cc/remote.py
+++ b/custom_components/ramses_cc/remote.py
@@ -11,7 +11,6 @@ from typing import Any, TypeAlias
 from ramses_rf.device.hvac import HvacRemote
 from ramses_rf.entity_base import Entity as RamsesRFEntity
 from ramses_tx import Command, Priority
-import voluptuous as vol  # type: ignore[import-untyped]
 
 from homeassistant.components.remote import (
     DOMAIN as PLATFORM,
@@ -21,7 +20,6 @@ from homeassistant.components.remote import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import Event, HomeAssistant, callback
-from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity_platform import (
     AddEntitiesCallback,
     EntityPlatform,
@@ -32,16 +30,13 @@ from homeassistant.helpers.typing import DiscoveryInfoType
 from . import RamsesEntity, RamsesEntityDescription
 from .broker import RamsesBroker
 from .const import (
-    ATTR_COMMAND,
-    ATTR_DELAY_SECS,
-    ATTR_NUM_REPEATS,
-    ATTR_TIMEOUT,
     BROKER,
     DOMAIN,
     SVC_DELETE_COMMAND,
     SVC_LEARN_COMMAND,
     SVC_SEND_COMMAND,
 )
+from .schemas import SCH_DELETE_COMMAND, SCH_LEARN_COMMAND, SCH_SEND_COMMAND
 
 
 @dataclass(kw_only=True)
@@ -50,29 +45,6 @@ class RamsesRemoteEntityDescription(RamsesEntityDescription, RemoteEntityDescrip
 
 
 _LOGGER = logging.getLogger(__name__)
-
-SVC_LEARN_COMMAND_SCHEMA = cv.make_entity_service_schema(
-    {
-        vol.Required(ATTR_COMMAND): cv.string,
-        vol.Required(ATTR_TIMEOUT, default=60): vol.All(
-            cv.positive_int, vol.Range(min=30, max=300)
-        ),
-    }
-)
-
-SVC_SEND_COMMAND_SCHEMA = cv.make_entity_service_schema(
-    {
-        vol.Required(ATTR_COMMAND): cv.string,
-        vol.Required(ATTR_NUM_REPEATS, default=3): cv.positive_int,
-        vol.Required(ATTR_DELAY_SECS, default=0.2): cv.positive_float,
-    },
-)
-
-SVC_DELETE_COMMAND_SCHEMA = cv.make_entity_service_schema(
-    {
-        vol.Required(ATTR_COMMAND): cv.string,
-    },
-)
 
 
 async def async_setup_platform(
@@ -93,13 +65,13 @@ async def async_setup_platform(
         platform: EntityPlatform = async_get_current_platform()
 
         platform.async_register_entity_service(
-            SVC_LEARN_COMMAND, SVC_LEARN_COMMAND_SCHEMA, "async_learn_command"
+            SVC_LEARN_COMMAND, SCH_LEARN_COMMAND, "async_learn_command"
         )
         platform.async_register_entity_service(
-            SVC_SEND_COMMAND, SVC_SEND_COMMAND_SCHEMA, "async_send_command"
+            SVC_SEND_COMMAND, SCH_SEND_COMMAND, "async_send_command"
         )
         platform.async_register_entity_service(
-            SVC_DELETE_COMMAND, SVC_DELETE_COMMAND_SCHEMA, "async_delete_command"
+            SVC_DELETE_COMMAND, SCH_DELETE_COMMAND, "async_delete_command"
         )
 
     entities = [


### PR DESCRIPTION
I'm inferring from recent changes that this is the preferred location/naming convention. I was just noticing that it was a bit odd having them split across multiple locations when merging into `config-flow`.