### PR TITLE
Consistent approach to entity ID generation across all platforms

### DIFF
--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -16,6 +16,7 @@ from ramses_tx.const import SZ_MODE, SZ_SETPOINT, SZ_SYSTEM_MODE
 
 from homeassistant.components.climate import (
     DOMAIN as PLATFORM,
+    ENTITY_ID_FORMAT,
     FAN_AUTO,
     FAN_HIGH,
     FAN_LOW,
@@ -166,7 +167,7 @@ class RamsesController(RamsesEntity, ClimateEntity):
         _LOGGER.info("Found controller %r", device)
         super().__init__(broker, device, entity_description)
 
-        self.entity_id = f"{PLATFORM}.{device.id}"
+        self.entity_id = ENTITY_ID_FORMAT.format(device.id)
 
     @property
     def current_temperature(self) -> float | None:
@@ -306,7 +307,7 @@ class RamsesZone(RamsesEntity, ClimateEntity):
         _LOGGER.info("Found zone %r", device)
         super().__init__(broker, device, entity_description)
 
-        self.entity_id = f"{PLATFORM}.{device.id}"
+        self.entity_id = ENTITY_ID_FORMAT.format(device.id)
 
     @property
     def current_temperature(self) -> float | None:
@@ -511,7 +512,7 @@ class RamsesHvac(RamsesEntity, ClimateEntity):
         _LOGGER.info("Found HVAC %r", device)
         super().__init__(broker, device, entity_description)
 
-        self.entity_id = f"{PLATFORM}.{device.id}"
+        self.entity_id = ENTITY_ID_FORMAT.format(device.id)
 
     @property
     def current_humidity(self) -> int | None:

--- a/custom_components/ramses_cc/remote.py
+++ b/custom_components/ramses_cc/remote.py
@@ -15,6 +15,7 @@ from ramses_tx.const import Priority
 
 from homeassistant.components.remote import (
     DOMAIN as PLATFORM,
+    ENTITY_ID_FORMAT,
     RemoteEntity,
     RemoteEntityDescription,
     RemoteEntityFeature,
@@ -94,7 +95,7 @@ class RamsesRemote(RamsesEntity, RemoteEntity):
         _LOGGER.info("Found %r", device)
         super().__init__(broker, device, entity_description)
 
-        self.entity_id = f"{DOMAIN}.{device.id}"
+        self.entity_id = ENTITY_ID_FORMAT.format(device.id)
 
         self._attr_is_on = True
         self._commands: dict[str, str] = broker._remotes.get(device.id, {})

--- a/custom_components/ramses_cc/sensor.py
+++ b/custom_components/ramses_cc/sensor.py
@@ -61,9 +61,9 @@ from ramses_tx.const import (
     SZ_TEMPERATURE,
 )
 
-from homeassistant.components.binary_sensor import ENTITY_ID_FORMAT
 from homeassistant.components.sensor import (
     DOMAIN as PLATFORM,
+    ENTITY_ID_FORMAT,
     SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,

--- a/custom_components/ramses_cc/water_heater.py
+++ b/custom_components/ramses_cc/water_heater.py
@@ -13,6 +13,7 @@ from ramses_tx.const import SZ_ACTIVE, SZ_MODE, SZ_SYSTEM_MODE
 
 from homeassistant.components.water_heater import (
     DOMAIN as PLATFORM,
+    ENTITY_ID_FORMAT,
     STATE_OFF,
     STATE_ON,
     WaterHeaterEntity,
@@ -109,7 +110,7 @@ class RamsesWaterHeater(RamsesEntity, WaterHeaterEntity):
         _LOGGER.info("Found DHW %r", device)
         super().__init__(broker, device, entity_description)
 
-        self.entity_id = f"{PLATFORM}.{device.id}"
+        self.entity_id = ENTITY_ID_FORMAT.format(device.id)
 
     @property
     def current_operation(self) -> str | None:


### PR DESCRIPTION
Uses ENTITY_ID_FORMAT for all platforms.

Also fixes incorrect prefix for remote and sensor. Interestingly this got corrected by HA but it's better if it's correct to start with!