### PR TITLE
Make HACS display name consistent with HA component

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,4 @@
 {
-    "name": "RAMSES CC",
+    "name": "RAMSES RF",
     "render_readme": true
 }


### PR DESCRIPTION
This is very minor but it struck me as odd that the HACS display name does not match the HA component/integration name.

As a side-note the description (read from the GitHub repo) could perhaps also be clearer. Maybe something along the lines of `HA integration for RAMSES II RF heating and HVAC systems.`?

Current:
<img width="500" alt="current" src="https://github.com/zxdavb/ramses_cc/assets/367121/c7b6d677-10ab-40a7-aa23-0513f4293d45">

Proposed:
<img width="500" alt="proposed" src="https://github.com/zxdavb/ramses_cc/assets/367121/7f97da1b-caeb-414e-a12b-2fc1a75fee0f">