### PR TITLE
Neaten entity descriptions

### DIFF
--- a/custom_components/ramses_cc/binary_sensor.py
+++ b/custom_components/ramses_cc/binary_sensor.py
@@ -209,21 +209,9 @@ class RamsesBinarySensorEntityDescription(
     icon_off: str | None = None
 
     # integration-specific attributes
-    ramses_cc_class: type[RamsesBinarySensor] = None  # type: ignore[assignment]
-    ramses_rf_attr: str = None  # type: ignore[assignment]
+    ramses_cc_class: type[RamsesBinarySensor] = RamsesBinarySensor
     ramses_rf_class: type[RamsesRFEntity] | UnionType = RamsesRFEntity
-
-    def __post_init__(self) -> None:
-        """Default values for descriptor attrs.
-
-        Is a convenience to avoid having to specify the values in the DESCRIPTOR table.
-        """
-
-        # HACK: may not be acceptible to HA core devs (should just complete the table)
-        object.__setattr__(self, "ramses_rf_attr", self.ramses_rf_attr or self.key)
-        object.__setattr__(
-            self, "ramses_cc_class", self.ramses_cc_class or RamsesBinarySensor
-        )
+    ramses_rf_attr: str
 
 
 BINARY_SENSOR_DESCRIPTIONS: tuple[RamsesBinarySensorEntityDescription, ...] = (
@@ -248,11 +236,13 @@ BINARY_SENSOR_DESCRIPTIONS: tuple[RamsesBinarySensorEntityDescription, ...] = (
     ),
     RamsesBinarySensorEntityDescription(
         key=TrvActuator.WINDOW_OPEN,
+        ramses_rf_attr=TrvActuator.WINDOW_OPEN,
         name="Window open",
         device_class=BinarySensorDeviceClass.WINDOW,
     ),
     RamsesBinarySensorEntityDescription(
         key=BdrSwitch.ACTIVE,
+        ramses_rf_attr=BdrSwitch.ACTIVE,
         name="Active",
         icon="mdi:electric-switch-closed",
         icon_off="mdi:electric-switch",
@@ -260,6 +250,7 @@ BINARY_SENSOR_DESCRIPTIONS: tuple[RamsesBinarySensorEntityDescription, ...] = (
     ),
     RamsesBinarySensorEntityDescription(
         key=BatteryState.BATTERY_LOW,
+        ramses_rf_attr=BatteryState.BATTERY_LOW,
         device_class=BinarySensorDeviceClass.BATTERY,
         ramses_cc_extra_attributes={
             ATTR_BATTERY_LEVEL: BatteryState.BATTERY_STATE,
@@ -267,8 +258,9 @@ BINARY_SENSOR_DESCRIPTIONS: tuple[RamsesBinarySensorEntityDescription, ...] = (
     ),
     RamsesBinarySensorEntityDescription(
         key="active_fault",
-        name="Active fault",
         ramses_rf_class=Logbook,
+        ramses_rf_attr="active_fault",
+        name="Active fault",
         ramses_cc_class=RamsesLogbookBinarySensor,
         device_class=BinarySensorDeviceClass.PROBLEM,
         ramses_cc_extra_attributes={
@@ -279,104 +271,122 @@ BINARY_SENSOR_DESCRIPTIONS: tuple[RamsesBinarySensorEntityDescription, ...] = (
     ),
     RamsesBinarySensorEntityDescription(
         key=SZ_CH_ACTIVE,
+        ramses_rf_attr=SZ_CH_ACTIVE,
         name="CH active",
         icon="mdi:radiator",
         icon_off="mdi:radiator-off",
     ),
     RamsesBinarySensorEntityDescription(
         key=SZ_CH_ENABLED,
+        ramses_rf_attr=SZ_CH_ENABLED,
         name="CH enabled",
         icon="mdi:radiator",
         icon_off="mdi:radiator-off",
     ),
     RamsesBinarySensorEntityDescription(
         key=SZ_COOLING_ACTIVE,
+        ramses_rf_attr=SZ_COOLING_ACTIVE,
         name="Cooling active",
         icon="mdi:snowflake",
         icon_off="mdi:snowflake-off",
     ),
     RamsesBinarySensorEntityDescription(
         key=SZ_COOLING_ENABLED,
+        ramses_rf_attr=SZ_COOLING_ENABLED,
         name="Cooling enabled",
         icon_off="mdi:snowflake-off",
         icon="mdi:snowflake",
     ),
     RamsesBinarySensorEntityDescription(
         key=SZ_DHW_ACTIVE,
+        ramses_rf_attr=SZ_DHW_ACTIVE,
         name="DHW active",
         icon_off="mdi:water-off",
         icon="mdi:water",
     ),
     RamsesBinarySensorEntityDescription(
         key=SZ_DHW_ENABLED,
+        ramses_rf_attr=SZ_DHW_ENABLED,
         name="DHW enabled",
         icon_off="mdi:water-off",
         icon="mdi:water",
     ),
     RamsesBinarySensorEntityDescription(
         key=SZ_FLAME_ACTIVE,
+        ramses_rf_attr=SZ_FLAME_ACTIVE,
         name="Flame active",
         icon="mdi:fire",
         icon_off="mdi:fire-off",
     ),
     RamsesBinarySensorEntityDescription(
         key=SZ_DHW_BLOCKING,
+        ramses_rf_attr=SZ_DHW_BLOCKING,
         name="DHW blocking",
     ),
     RamsesBinarySensorEntityDescription(
         key=SZ_OTC_ACTIVE,
+        ramses_rf_attr=SZ_OTC_ACTIVE,
         name="OTC active",
         icon="mdi:weather-snowy-heavy",
     ),
     RamsesBinarySensorEntityDescription(
         key=SZ_SUMMER_MODE,
+        ramses_rf_attr=SZ_SUMMER_MODE,
         name="Summer mode",
         icon="mdi:sun-clock",
     ),
     RamsesBinarySensorEntityDescription(
         key=SZ_FAULT_PRESENT,
+        ramses_rf_attr=SZ_FAULT_PRESENT,
         icon="mdi:alert",
         name="Fault present",
     ),
     RamsesBinarySensorEntityDescription(
         key=SZ_BYPASS_POSITION,
+        ramses_rf_attr=SZ_BYPASS_POSITION,
         name="Bypass position",
     ),
     # Special projects
     RamsesBinarySensorEntityDescription(
         key="bit_2_4",
-        name="Bit 2/4",
         ramses_rf_class=OtbGateway,
+        ramses_rf_attr="bit_2_4",
+        name="Bit 2/4",
         entity_registry_enabled_default=False,
     ),
     RamsesBinarySensorEntityDescription(
         key="bit_2_5",
-        name="Bit 2/5",
         ramses_rf_class=OtbGateway,
+        ramses_rf_attr="bit_2_5",
+        name="Bit 2/5",
         entity_registry_enabled_default=False,
     ),
     RamsesBinarySensorEntityDescription(
         key="bit_2_6",
-        name="Bit 2/6",
         ramses_rf_class=OtbGateway,
+        ramses_rf_attr="bit_2_6",
+        name="Bit 2/6",
         entity_registry_enabled_default=False,
     ),
     RamsesBinarySensorEntityDescription(
         key="bit_2_7",
-        name="Bit 2/7",
         ramses_rf_class=OtbGateway,
+        ramses_rf_attr="bit_2_7",
+        name="Bit 2/7",
         entity_registry_enabled_default=False,
     ),
     RamsesBinarySensorEntityDescription(
         key="bit_3_7",
-        name="Bit 3/7",
         ramses_rf_class=OtbGateway,
+        ramses_rf_attr="bit_3_7",
+        name="Bit 3/7",
         entity_registry_enabled_default=False,
     ),
     RamsesBinarySensorEntityDescription(
         key="bit_6_6",
-        name="Bit 6/6",
         ramses_rf_class=OtbGateway,
+        ramses_rf_attr="bit_6_6",
+        name="Bit 6/6",
         entity_registry_enabled_default=False,
     ),
 )

--- a/custom_components/ramses_cc/sensor.py
+++ b/custom_components/ramses_cc/sensor.py
@@ -250,27 +250,16 @@ class RamsesSensorEntityDescription(RamsesEntityDescription, SensorEntityDescrip
     # integration-specific attributes
     ramses_cc_class: type[RamsesSensor] = RamsesSensor
     ramses_cc_icon_off: str | None = None  # no SensorEntityDescription.icon_off attr
-    ramses_rf_attr: str = None  # type: ignore[assignment]
     ramses_rf_class: type[RamsesRFEntity] | UnionType = RamsesRFEntity
-
-    def __post_init__(self) -> None:
-        """Default values for descriptor attrs.
-
-        Is a convenience to avoid having to specify the values in the DESCRIPTOR table.
-        """
-
-        # HACK: may not be acceptible to HA core devs (should just complete the table)
-        object.__setattr__(self, "ramses_rf_attr", self.ramses_rf_attr or self.key)
-        object.__setattr__(
-            self, "ramses_cc_class", self.ramses_cc_class or RamsesSensor
-        )
+    ramses_rf_attr: str
 
 
 SENSOR_DESCRIPTIONS: tuple[RamsesSensorEntityDescription, ...] = (
     RamsesSensorEntityDescription(
         key=SZ_TEMPERATURE,
-        device_class=SensorDeviceClass.TEMPERATURE,
         ramses_rf_class=HvacHumiditySensor | TrvActuator,
+        ramses_rf_attr=SZ_TEMPERATURE,
+        device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         ramses_cc_extra_attributes={
             ATTR_SETPOINT: SZ_SETPOINT,
@@ -278,8 +267,9 @@ SENSOR_DESCRIPTIONS: tuple[RamsesSensorEntityDescription, ...] = (
     ),
     RamsesSensorEntityDescription(
         key=SZ_TEMPERATURE,
-        device_class=SensorDeviceClass.TEMPERATURE,
         ramses_rf_class=DhwSensor | OutSensor | Thermostat,
+        ramses_rf_attr=SZ_TEMPERATURE,
+        device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         entity_category=None,
         ramses_cc_extra_attributes={
@@ -288,31 +278,35 @@ SENSOR_DESCRIPTIONS: tuple[RamsesSensorEntityDescription, ...] = (
     ),
     RamsesSensorEntityDescription(
         key=SZ_DEWPOINT_TEMP,
+        ramses_rf_class=HvacHumiditySensor,
+        ramses_rf_attr=SZ_DEWPOINT_TEMP,
         name="Dewpoint temperature",
         icon="mdi:water-thermometer",
         device_class=SensorDeviceClass.TEMPERATURE,
-        ramses_rf_class=HvacHumiditySensor,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
     ),
     RamsesSensorEntityDescription(
         key=SZ_HEAT_DEMAND,
+        ramses_rf_class=OtbGateway,
+        ramses_rf_attr=SZ_HEAT_DEMAND,
         name="Heat demand",
         icon="mdi:radiator",
         ramses_cc_icon_off="mdi:radiator-off",
-        ramses_rf_class=OtbGateway,
         native_unit_of_measurement=PERCENTAGE,
     ),
     RamsesSensorEntityDescription(  # not OtbGateway
         key=SZ_HEAT_DEMAND,
+        ramses_rf_class=SystemBase | TrvActuator | UfhController | ZoneBase,
+        ramses_rf_attr=SZ_HEAT_DEMAND,
         name="Heat demand",
         icon="mdi:radiator",
         ramses_cc_icon_off="mdi:radiator-off",
-        ramses_rf_class=SystemBase | TrvActuator | UfhController | ZoneBase,
         native_unit_of_measurement=PERCENTAGE,
         entity_category=None,
     ),
     RamsesSensorEntityDescription(
         key=SZ_RELAY_DEMAND,
+        ramses_rf_attr=SZ_RELAY_DEMAND,
         name="Relay demand",
         icon="mdi:power-plug",
         ramses_cc_icon_off="mdi:power-plug-off",
@@ -320,6 +314,7 @@ SENSOR_DESCRIPTIONS: tuple[RamsesSensorEntityDescription, ...] = (
     ),
     RamsesSensorEntityDescription(
         key=f"{SZ_RELAY_DEMAND}_fa",
+        ramses_rf_attr=f"{SZ_RELAY_DEMAND}_fa",
         name="Relay demand (FA)",
         icon="mdi:power-plug",
         ramses_cc_icon_off="mdi:power-plug-off",
@@ -328,106 +323,124 @@ SENSOR_DESCRIPTIONS: tuple[RamsesSensorEntityDescription, ...] = (
     ),
     RamsesSensorEntityDescription(
         key=SZ_BOILER_OUTPUT_TEMP,
+        ramses_rf_attr=SZ_BOILER_OUTPUT_TEMP,
         name="Boiler output temperature",
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
     ),
     RamsesSensorEntityDescription(
         key=SZ_BOILER_RETURN_TEMP,
+        ramses_rf_attr=SZ_BOILER_RETURN_TEMP,
         name="Boiler return temperature",
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
     ),
     RamsesSensorEntityDescription(
         key=SZ_BOILER_SETPOINT,
+        ramses_rf_attr=SZ_BOILER_SETPOINT,
         name="Boiler setpoint",
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
     ),
     RamsesSensorEntityDescription(
         key=SZ_CH_SETPOINT,
+        ramses_rf_attr=SZ_CH_SETPOINT,
         name="CH setpoint",
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
     ),
     RamsesSensorEntityDescription(
         key=SZ_CH_MAX_SETPOINT,
+        ramses_rf_attr=SZ_CH_MAX_SETPOINT,
         name="CH max setpoint",
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
     ),
     RamsesSensorEntityDescription(
         key=SZ_CH_WATER_PRESSURE,
+        ramses_rf_attr=SZ_CH_WATER_PRESSURE,
         name="CH water pressure",
         device_class=SensorDeviceClass.PRESSURE,
         native_unit_of_measurement=UnitOfPressure.BAR,
     ),
     RamsesSensorEntityDescription(
         key=SZ_DHW_FLOW_RATE,
+        ramses_rf_attr=SZ_DHW_FLOW_RATE,
         name="DHW flow rate",
         native_unit_of_measurement=UnitOfVolumeFlowRate.LITERS_PER_MINUTE,
     ),
     RamsesSensorEntityDescription(
         key=SZ_DHW_SETPOINT,
+        ramses_rf_attr=SZ_DHW_SETPOINT,
         name="DHW setpoint",
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
     ),
     RamsesSensorEntityDescription(
         key=SZ_DHW_TEMP,
+        ramses_rf_attr=SZ_DHW_TEMP,
         name="DHW temperature",
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
     ),
     RamsesSensorEntityDescription(
         key=SZ_OUTSIDE_TEMP,
+        ramses_rf_attr=SZ_OUTSIDE_TEMP,
         name="Outside temperature",
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
     ),
     RamsesSensorEntityDescription(
         key=SZ_REL_MODULATION_LEVEL,
+        ramses_rf_attr=SZ_REL_MODULATION_LEVEL,
         name="Relative modulation level",
         native_unit_of_measurement=PERCENTAGE,
         entity_category=None,
     ),
     RamsesSensorEntityDescription(
         key=SZ_MAX_REL_MODULATION,
+        ramses_rf_attr=SZ_MAX_REL_MODULATION,
         name="Max relative modulation level",
         native_unit_of_measurement=PERCENTAGE,
     ),
     # HVAC (mostly ventilation units)
     RamsesSensorEntityDescription(
         key=SZ_AIR_QUALITY,
+        ramses_rf_attr=SZ_AIR_QUALITY,
         name="Air quality",
         native_unit_of_measurement=PERCENTAGE,
         entity_category=None,
     ),
     RamsesSensorEntityDescription(
         key=SZ_AIR_QUALITY_BASIS,
+        ramses_rf_attr=SZ_AIR_QUALITY_BASIS,
         name="Air quality basis",
         native_unit_of_measurement=PERCENTAGE,
     ),
     RamsesSensorEntityDescription(
         key=SZ_CO2_LEVEL,
+        ramses_rf_attr=SZ_CO2_LEVEL,
         device_class=SensorDeviceClass.CO2,
         native_unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION,
         entity_category=None,
     ),
     RamsesSensorEntityDescription(
         key=SZ_EXHAUST_FAN_SPEED,
+        ramses_rf_attr=SZ_EXHAUST_FAN_SPEED,
         name="Exhaust fan speed",
         native_unit_of_measurement=PERCENTAGE,
         entity_category=None,
     ),
     RamsesSensorEntityDescription(
         key=SZ_EXHAUST_FLOW,
+        ramses_rf_attr=SZ_EXHAUST_FLOW,
         name="Exhaust flow",
         native_unit_of_measurement=UnitOfVolumeFlowRate.LITERS_PER_SECOND,
         entity_category=None,
     ),
     RamsesSensorEntityDescription(
         key=SZ_EXHAUST_TEMP,
+        ramses_rf_attr=SZ_EXHAUST_TEMP,
         name="Exhaust temperature",
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
@@ -435,16 +448,19 @@ SENSOR_DESCRIPTIONS: tuple[RamsesSensorEntityDescription, ...] = (
     ),
     RamsesSensorEntityDescription(
         key=SZ_FAN_INFO,
+        ramses_rf_attr=SZ_FAN_INFO,
         name="Fan info",
         state_class=None,
     ),
     RamsesSensorEntityDescription(
         key=SZ_FILTER_REMAINING,
+        ramses_rf_attr=SZ_FILTER_REMAINING,
         name="Filter remaining",
         native_unit_of_measurement=UnitOfTime.DAYS,
     ),
     RamsesSensorEntityDescription(
         key=SZ_INDOOR_HUMIDITY,
+        ramses_rf_attr=SZ_INDOOR_HUMIDITY,
         name="Indoor humidity",
         device_class=SensorDeviceClass.HUMIDITY,
         native_unit_of_measurement=PERCENTAGE,
@@ -452,6 +468,7 @@ SENSOR_DESCRIPTIONS: tuple[RamsesSensorEntityDescription, ...] = (
     ),
     RamsesSensorEntityDescription(
         key=SZ_INDOOR_TEMP,
+        ramses_rf_attr=SZ_INDOOR_TEMP,
         name="Indoor temperature",
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
@@ -459,6 +476,7 @@ SENSOR_DESCRIPTIONS: tuple[RamsesSensorEntityDescription, ...] = (
     ),
     RamsesSensorEntityDescription(
         key=SZ_OUTDOOR_HUMIDITY,
+        ramses_rf_attr=SZ_OUTDOOR_HUMIDITY,
         name="Outdoor humidity",
         device_class=SensorDeviceClass.HUMIDITY,
         native_unit_of_measurement=PERCENTAGE,
@@ -466,6 +484,7 @@ SENSOR_DESCRIPTIONS: tuple[RamsesSensorEntityDescription, ...] = (
     ),
     RamsesSensorEntityDescription(
         key=SZ_OUTDOOR_TEMP,
+        ramses_rf_attr=SZ_OUTDOOR_TEMP,
         name="Outdoor temperature",
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
@@ -473,39 +492,46 @@ SENSOR_DESCRIPTIONS: tuple[RamsesSensorEntityDescription, ...] = (
     ),
     RamsesSensorEntityDescription(
         key=SZ_POST_HEAT,
+        ramses_rf_attr=SZ_POST_HEAT,
         name="Post heat",
         native_unit_of_measurement=PERCENTAGE,
         entity_category=None,
     ),
     RamsesSensorEntityDescription(
         key=SZ_PRE_HEAT,
+        ramses_rf_attr=SZ_PRE_HEAT,
         name="Pre heat",
         native_unit_of_measurement=PERCENTAGE,
         entity_category=None,
     ),
     RamsesSensorEntityDescription(
         key=SZ_REMAINING_MINS,
+        ramses_rf_attr=SZ_REMAINING_MINS,
         name="Remaining time",
         native_unit_of_measurement=UnitOfTime.MINUTES,
     ),
     RamsesSensorEntityDescription(
         key=SZ_SPEED_CAPABILITIES,
+        ramses_rf_attr=SZ_SPEED_CAPABILITIES,
         name="Speed cap",
         native_unit_of_measurement="units",
     ),
     RamsesSensorEntityDescription(
         key=SZ_SUPPLY_FAN_SPEED,
+        ramses_rf_attr=SZ_SUPPLY_FAN_SPEED,
         name="Supply fan speed",
         native_unit_of_measurement=PERCENTAGE,
     ),
     RamsesSensorEntityDescription(
         key=SZ_SUPPLY_FLOW,
+        ramses_rf_attr=SZ_SUPPLY_FLOW,
         name="Supply flow",
         native_unit_of_measurement=UnitOfVolumeFlowRate.LITERS_PER_SECOND,
         entity_category=None,
     ),
     RamsesSensorEntityDescription(
         key=SZ_SUPPLY_TEMP,
+        ramses_rf_attr=SZ_SUPPLY_TEMP,
         name="Supply temperature",
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
@@ -514,15 +540,17 @@ SENSOR_DESCRIPTIONS: tuple[RamsesSensorEntityDescription, ...] = (
     # Special projects
     RamsesSensorEntityDescription(
         key=SZ_OEM_CODE,
-        name="OEM code",
         ramses_rf_class=OtbGateway,
+        ramses_rf_attr=SZ_OEM_CODE,
+        name="OEM code",
         state_class=None,
         entity_registry_enabled_default=False,
     ),
     RamsesSensorEntityDescription(
         key="percent",
-        name="Percent",
         ramses_rf_class=OtbGateway,
+        ramses_rf_attr="percent",
+        name="Percent",
         icon="mdi:power-plug",
         ramses_cc_icon_off="mdi:power-plug-off",
         native_unit_of_measurement=PERCENTAGE,
@@ -530,8 +558,9 @@ SENSOR_DESCRIPTIONS: tuple[RamsesSensorEntityDescription, ...] = (
     ),
     RamsesSensorEntityDescription(
         key="value",
-        name="Value",
         ramses_rf_class=OtbGateway,
+        ramses_rf_attr="value",
+        name="Value",
         native_unit_of_measurement="units",
         entity_registry_enabled_default=False,
     ),


### PR DESCRIPTION
Explicitly set `ramses_rf_attr` so we no longer need to default these.

Follow on from https://github.com/zxdavb/ramses_cc/pull/148#issuecomment-1921031732