### PR TITLE
Add impersonation support to send_packet service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ __snapshots__
 
 !custom_components/ramses_cc
 !custom_components/ramses_cc/manifest.json
+!custom_components/ramses_cc/services.yaml
 
 !.flake8
 !.gitignore

--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -232,7 +232,7 @@ SCH_BIND_DEVICE = vol.Schema(
 SCH_SEND_PACKET = vol.Schema(
     {
         vol.Required(ATTR_DEVICE_ID): _SCH_DEVICE_ID,
-        Vol.Optional("from_id"): _SCH_DEVICE_ID,
+        vol.Optional("from_id"): _SCH_DEVICE_ID,
         vol.Required("verb"): vol.In((" I", "I", "RQ", "RP", " W", "W")),
         vol.Required("code"): cv.matches_regex(r"^[0-9A-F]{4}$"),
         vol.Required("payload"): cv.matches_regex(r"^([0-9A-F][0-9A-F]){1,48}$"),

--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -231,7 +231,8 @@ SCH_BIND_DEVICE = vol.Schema(
 
 SCH_SEND_PACKET = vol.Schema(
     {
-        vol.Required(ATTR_DEVICE_ID): cv.matches_regex(r"^[0-9]{2}:[0-9]{6}$"),
+        vol.Required(ATTR_DEVICE_ID): _SCH_DEVICE_ID,
+        Vol.Optional("from_id"): _SCH_DEVICE_ID,
         vol.Required("verb"): vol.In((" I", "I", "RQ", "RP", " W", "W")),
         vol.Required("code"): cv.matches_regex(r"^[0-9A-F]{4}$"),
         vol.Required("payload"): cv.matches_regex(r"^([0-9A-F][0-9A-F]){1,48}$"),

--- a/custom_components/ramses_cc/services.yaml
+++ b/custom_components/ramses_cc/services.yaml
@@ -69,7 +69,7 @@ send_packet:
       description: >-
         The source device ID (a RAMSES ID, not an entity_id).
         This can be used to send a packet from a faked device.
-        If not specified, the device ID of the gateway is used.
+        Optional: if not specified, the device ID of the gateway is used.
       example: 18:123456
       required: false
 

--- a/custom_components/ramses_cc/services.yaml
+++ b/custom_components/ramses_cc/services.yaml
@@ -65,6 +65,14 @@ send_packet:
       example: 01:123456
       required: true
 
+    from_id:
+      description: >-
+        The source device ID (a RAMSES ID, not an entity_id).
+        This can be used to send a packet from a faked device.
+        If not specified, the device ID of the gateway is used.
+      example: 18:123456
+      required: false
+
     verb:
       description: 'The packet verb, one of: I, RQ, RP, W (leading space not required).'
       example: RQ

--- a/custom_components/ramses_cc/translations/en.json
+++ b/custom_components/ramses_cc/translations/en.json
@@ -152,7 +152,7 @@
             "advanced_features": {
                 "title": "Advanced features",
                 "data": {
-                    "send_packet": "Enable send_packet service for broadcasting bespoke packets",
+                    "send_packet": "Enable send_packet service for sending bespoke packets",
                     "message_events": "Emit events for messages matching regular expression"
                 },
                 "data_description": {

--- a/custom_components/ramses_cc/translations/en.json
+++ b/custom_components/ramses_cc/translations/en.json
@@ -152,7 +152,7 @@
             "advanced_features": {
                 "title": "Advanced features",
                 "data": {
-                    "send_packet": "Enable send_packet service for sending bespoke packets",
+                    "send_packet": "Enable send_packet service for casting bespoke packets",
                     "message_events": "Emit events for messages matching regular expression"
                 },
                 "data_description": {

--- a/tests/tests_old/test_services.py
+++ b/tests/tests_old/test_services.py
@@ -100,7 +100,7 @@ TEST_CONFIG = {
         "32:097710": {"class": "CO2"},
         "32:139773": {"class": "HUM"},
         "37:123456": {"class": "FAN"},
-        "40:123456": {"class": "REM", "faked": True}
+        "40:123456": {"class": "REM", "faked": True},
     },
 }
 
@@ -795,7 +795,10 @@ async def test_svc_send_packet(hass: HomeAssistant, entry: ConfigEntry) -> None:
 
     await _test_service_call(hass, SVC_SEND_PACKET, data, schemas=schemas)
 
-async def test_svc_send_packet_with_impersonation(hass: HomeAssistant, entry: ConfigEntry) -> None:
+
+async def test_svc_send_packet_with_impersonation(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> None:
     """Test the service call."""
 
     data = {

--- a/tests/tests_old/test_services.py
+++ b/tests/tests_old/test_services.py
@@ -100,6 +100,7 @@ TEST_CONFIG = {
         "32:097710": {"class": "CO2"},
         "32:139773": {"class": "HUM"},
         "40:123456": {"class": "REM", "faked": True},
+        "37:123456": {"class": "FAN"}
     },
 }
 
@@ -789,6 +790,20 @@ async def test_svc_send_packet(hass: HomeAssistant, entry: ConfigEntry) -> None:
         "verb": " I",
         "code": "1FC9",
         "payload": "00",
+    }
+    schemas = {SVC_SEND_PACKET: SCH_SEND_PACKET}
+
+    await _test_service_call(hass, SVC_SEND_PACKET, data, schemas=schemas)
+
+async def test_svc_send_packet_with_impersonation(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Test the service call."""
+
+    data = {
+        "device_id": "32:123456",
+        "from_id": "40:123456",
+        "verb": " I",
+        "code": "22F1",
+        "payload": "000304",
     }
     schemas = {SVC_SEND_PACKET: SCH_SEND_PACKET}
 

--- a/tests/tests_old/test_services.py
+++ b/tests/tests_old/test_services.py
@@ -99,8 +99,8 @@ TEST_CONFIG = {
         "03:123456": {"class": "THM", "faked": True},
         "32:097710": {"class": "CO2"},
         "32:139773": {"class": "HUM"},
-        "40:123456": {"class": "REM", "faked": True},
-        "37:123456": {"class": "FAN"}
+        "37:123456": {"class": "FAN"},
+        "40:123456": {"class": "REM", "faked": True}
     },
 }
 

--- a/tests/tests_old/test_services.py
+++ b/tests/tests_old/test_services.py
@@ -799,7 +799,7 @@ async def test_svc_send_packet_with_impersonation(hass: HomeAssistant, entry: Co
     """Test the service call."""
 
     data = {
-        "device_id": "32:123456",
+        "device_id": "37:123456",
         "from_id": "40:123456",
         "verb": " I",
         "code": "22F1",


### PR DESCRIPTION
This change adds support for impersonation using the send_packet service.

I use it to send fan_demand packets from my faked CO2 sensor, because ramses_rf doesn't support that yet.

I couldn't practically solve this use-case with a remote, because you have to predefine the commands in a remote, which is not very suitable for fan_demand packets, since you specify the demand percentage - you would need to create 100 commands for it.

I submitted this PR before, I hope you would consider merging it. If not, I will have to switch to using my own fork instead.