### PR TITLE
Services i18n

### DIFF
--- a/custom_components/ramses_cc/services.yaml
+++ b/custom_components/ramses_cc/services.yaml
@@ -1,13 +1,11 @@
 #
 # integration-wide service calls
+# See for UI translated strings ./translations/lang.json
 
 bind_device:
   # Bind a Device
-  name: see ./translations/lang.json
   fields:
     device_id:
-      name: notused but can't be empty
-      description: notused
       # The device id of the supplicant.
       example: 03:123456
       required: true
@@ -32,7 +30,6 @@ force_update:
 
 send_packet:
   # Send a completely bespoke RAMSES II command packet from the gateway.
-  name: see ./translations/lang.json
   fields:
     device_id:
       example: 01:123456
@@ -47,12 +44,10 @@ send_packet:
       required: true
 
     code:
-      name: not used
       example: 1F09
       required: true
 
     payload:
-      name: not used
       example: '"00"'
       required: true
 
@@ -66,8 +61,6 @@ get_system_faults:
   fields:
     entity_id: &entity_id_system
       # Controller
-      name: notused but can't be empty
-      description: notused
       example: climate.01_123456
       required: true
       selector:
@@ -77,7 +70,6 @@ get_system_faults:
 
     num_entries:
       # Number of log entries
-      name: see ./translations/lang.json
       example: 8
       selector:
         number:
@@ -143,8 +135,6 @@ get_zone_schedule:
   fields:
     entity_id: &entity_id_zone
       # Zone
-      name: notused but can't be empty
-      description: notused
       example: climate.01_123456_02
       required: true
       selector:
@@ -264,8 +254,6 @@ get_dhw_schedule:
   fields:
     entity_id: &entity_id_dhw
       # Stored DHW
-      name: notused but can't be empty
-      description: notused
       example: water_heater.01_123456_hw
       required: true
       selector:
@@ -384,7 +372,7 @@ set_dhw_schedule:
           multiline: true
 
 
-#
+
 # faked entity service calls
 
 fake_zone_temp:
@@ -393,8 +381,6 @@ fake_zone_temp:
   fields:
     entity_id:
       # Zone
-      name: notused but can't be empty
-      description: notused
       example: climate.01_123456_02
       required: true
       selector:
@@ -420,8 +406,6 @@ fake_dhw_temp:
   fields:
     entity_id:
       # Stored HW
-      name: notused but can't be empty
-      description: notused
       example: water_heater.01_123456
       required: true
       selector:
@@ -450,8 +434,6 @@ put_room_temp:
   fields:
     entity_id:
       # Thermostat
-      name: notused but can't be empty
-      description: notused
       example: sensor.03_123456_temperature
       required: true
       selector:
@@ -478,8 +460,6 @@ put_dhw_temp:
   fields:
     entity_id:
       # Stored DHW
-      name: notused but can't be empty
-      description: notused
       example: sensor.07_123456_temperature
       required: true
       selector:
@@ -505,8 +485,6 @@ put_co2_level:
 
   fields:
     entity_id:
-      name: notused but can't be empty
-      description: notused
       example: sensor.30_123456_co2_level
       required: true
       selector:
@@ -516,8 +494,6 @@ put_co2_level:
           device_class: carbon_dioxide
 
     co2_level:
-      name: notused but can't be empty
-      description: notused
       required: true
       example: 363
       selector:
@@ -534,8 +510,6 @@ put_indoor_humidity:
 
   fields:
     entity_id:
-      name: notused but can't be empty
-      description: notused
       example: sensor.30_123456_indoor_humidity
       required: true
       selector:
@@ -545,8 +519,6 @@ put_indoor_humidity:
           device_class: humidity
 
     indoor_humidity:
-      name: notused but can't be empty
-      description: notused
       required: true
       example: 59.3
       selector:
@@ -566,8 +538,6 @@ delete_command:
 
   fields:
     entity_id: &entity_id_remote
-      name: notused but can't be empty
-      description: notused
       required: true
       example: remote.30_123456
       selector:
@@ -576,8 +546,6 @@ delete_command:
           domain: remote
 
     command: &command_remote
-      name: notused but can't be empty
-      description: notused
       required: true
       example: Boost
       selector:

--- a/custom_components/ramses_cc/services.yaml
+++ b/custom_components/ramses_cc/services.yaml
@@ -2,98 +2,57 @@
 # integration-wide service calls
 
 bind_device:
-  name: Bind a Device
-  description: >-
-    Bind a device to a CH/DHW controller or a fan/ventilation unit.
-
-    The device will be either a sensor (e.g. temperature, humidity, etc.) or a
-    remote (e.g. a 4-way switch).
-
-    It must be included in the known_list and correctly configured with an
-    appropriate class and faking enabled.
-
+  # Bind a Device
+  name: see ./translations/lang.json
   fields:
     device_id:
-      name: Supplicant device_id
-      description: >-
-        The device id of the supplicant.
-
-        Heating (CH/DHW) devices ids must start with a well-known device type.
-        HVAC devices ids should start with a device type that is consistent with their
-        hardware manufacturer's scheme.
+      name: notused but can't be empty
+      description: notused
+      # The device id of the supplicant.
       example: 03:123456
       required: true
 
     offer:
-      name: Offer
-      description: >-
-        The command_code / domain_idx pairs for the binding offer.
-
-        If you include '10E0' (device info), ensure the domain id is set to the
-        hardware manufacturer's oem_code.
+      # The command_code / domain_idx pairs for the binding offer.
       example: '{"30C9": "00"}'
       required: true
 
     confirm:
-      name: Confirm
-      description: >-
-        The command_code / domain_idx pairs for the binding confirmation, if required.
+      # The command_code / domain_idx pairs for the binding confirmation, if required.
       required: false
 
     device_info:
-      name: Device info
-      description: >-
-        The device_info command of the supplicant (needed to complete some bindings).
-
-        This is required if you include 10E0 (device info) within the offer.
-        It must be the correct payload for the device class.
+      # The device_info command of the supplicant (needed to complete some bindings).
       required: false
 
 
 force_update:
-  name: Update the System state
-  description: >-
-    Immediately update the system state, without waiting for the next scheduled update.
+  # Immediately update the system state, without waiting for the next scheduled update.
 
 
 send_packet:
-  name: Send a Command packet
-  description: >-
-    Send a completely bespoke RAMSES II command packet from the gateway.
-
+  # Send a completely bespoke RAMSES II command packet from the gateway.
+  name: see ./translations/lang.json
   fields:
     device_id:
-      name: Destination ID
-      description: >-
-        The destination device ID (a RAMSES ID, not an entity_id).
-        Use "18:000730" (a sentinel value) to send a broadcast from the gateway.
       example: 01:123456
       required: true
 
     from_id:
-      name: Source ID
-      description: >-
-        The source device ID (a RAMSES ID, not an entity_id).
-        This can be used to send a packet from a faked device.
-        Optional: if not specified, the device ID of the gateway is used.
       example: 18:123456
       required: false
 
     verb:
-      name: Packet verb
-      description: 'The packet verb, one of: I, RQ, RP, W (leading space not required).'
       example: RQ
       required: true
 
     code:
-      name: Packet code
-      description: The packet code (class).
+      name: not used
       example: 1F09
       required: true
 
     payload:
-      name: Payload as hex
-      description: The packet payload as a hexadecimal string.
+      name: not used
       example: '"00"'
       required: true
 
@@ -102,17 +61,13 @@ send_packet:
 # evohome controller service calls (CH/DHW)
 
 get_system_faults:
-  name: Get the Fault log of a TCS (Controller)
-  description: >-
-    Obtains the controllers's latest fault log entries.
+  # Get the Fault log of a TCS (Controller)
 
   fields:
     entity_id: &entity_id_system
-      name: Controller
-      description: >-
-        The entity_id of the evohome Controller (TCS, temperature control system).
-        NB: Most of this integration's climate entities are not Controllers
-        (such entities, e.g. zones, will raise an AttributeError).
+      # Controller
+      name: notused but can't be empty
+      description: notused
       example: climate.01_123456
       required: true
       selector:
@@ -121,45 +76,33 @@ get_system_faults:
           domain: climate
 
     num_entries:
-      name: Number of log entries
-      description: >-
-        The number of fault log entries to retrieve. Default is 8.
+      # Number of log entries
+      name: see ./translations/lang.json
       example: 8
       selector:
         number:
           min: 1
           max: 64
           step: 1
-          unit_of_measurement: entries
+          # unit_of_measurement: entries
           mode: slider
 
 
 reset_system_mode:
-  name: Fully reset the Mode of a TCS (Controller)
-  description: >-
-    The system will be in auto mode and all zones will be in follow_schedule mode,
-    including (if supported) those in permanent_override mode.
+  #Fully reset the Mode of a TCS (Controller)
 
   fields:
     entity_id: *entity_id_system
 
 
 set_system_mode:
-  name: Set the Mode of a TCS (Controller)
-  description: >-
-    The system will be in the new mode and all zones not in permanent_override mode
-    will be affected.
-    Some modes have the option of a period (of days), others a duration (of hours/minutes).
+  # Set the Mode of a TCS (Controller)
 
   fields:
     entity_id: *entity_id_system
 
     mode:
-      name: System Mode
-      description: >-
-        One of: auto, eco_boost, away, day_off, day_off_eco, heat_off, or custom.
-        All modes can be set indefinitely, some can be set for a period of days,
-        and others for a duration in hours/minutes.
+      # System Mode
       default: auto
       example: away
       required: true
@@ -176,11 +119,7 @@ set_system_mode:
             - custom
 
     period:
-      name: Period (days)
-      description: >-
-        Optional. A period of time in days; valid only with away, day_off, day_off_eco
-        or custom.
-        The system will revert to auto at midnight (up to 99 days, 0 is until midnight tonight).
+      # Period (days)
       default: {days: 0}
       example: {days: 28}
       selector:
@@ -188,9 +127,7 @@ set_system_mode:
           enable_day: true
 
     duration:
-      name: Duration (hours/minutes)
-      description: >-
-        Optional. The duration in hours/minutes (up to 24h); valid only with eco_boost.
+      # Duration (hours/minutes)
       default: {hours: 1}
       example: {hours: 2, minutes: 30}
       selector:
@@ -201,24 +138,13 @@ set_system_mode:
 # evohome zone service calls (CH/DHW)
 
 get_zone_schedule:
-  name: Get the Weekly schedule of a Zone
-  description: >-
-    Obtains the zone's latest weekly schedule from the controller and updates the
-    entity's state attributes with that data.
-
-    The schedule will be available at:
-    `{{ state_attr('climate.main_room', 'schedule') }}`
-
-    Note: only evohome-compatible zones have schedules and not all of this integration's
-    climate entities are such zones (will raise a TypeError).
+  # Get the Weekly schedule of a Zone
 
   fields:
     entity_id: &entity_id_zone
-      name: Zone
-      description: >-
-        The entity_id of the evohome Zone.
-        NB: Some of this integration's climate entities are not Zones
-        (such entities, e.g. Controllers, will raise an AttributeError).
+      # Zone
+      name: notused but can't be empty
+      description: notused
       example: climate.01_123456_02
       required: true
       selector:
@@ -228,36 +154,30 @@ get_zone_schedule:
 
 
 put_zone_temp:
-  name: Fake the Sensor temperature of a Zone
-  description: Currently deprecated, use `fake_zone_temp` or `put_room_temp` instead.
+  # Fake the Sensor temperature of a Zone
 
 
 reset_zone_config:
-  name: Reset the Configuration of a Zone
-  description: Reset the configuration of the zone.
+  # Reset the Configuration of a Zone
 
   fields:
     entity_id: *entity_id_zone
 
 
 reset_zone_mode:
-  name: Reset the Mode of a Zone
-  description: Reset the operating mode of the zone.
+  # Reset the Mode of a Zone
 
   fields:
     entity_id: *entity_id_zone
 
 
 set_zone_config:
-  name: Set the Configuration of a Zone
-  description: Reset the configuration of the zone.
+  # Set the Configuration of a Zone
 
   fields:
     entity_id: *entity_id_zone
 
     min_temp:
-      name: Minimum
-      description: The minimum permitted setpoint in degrees Celsius (5-21 °C).
       example: 5
       selector:
         number:
@@ -268,8 +188,6 @@ set_zone_config:
           mode: slider
 
     max_temp:
-      name: Maximum
-      description: The maximum permitted setpoint in degrees Celsius (21-35 °C).
       example: 30
       selector:
         number:
@@ -281,19 +199,13 @@ set_zone_config:
 
 
 set_zone_mode:
-  name: Set the Mode of a Zone
-  description: >-
-    Set the operating mode of the zone, either indefinitely or for a given duration.
+  # Set the Mode of a Zone
 
   fields:
     entity_id: *entity_id_zone
 
     mode:
-      name: Zone Mode
-      description: >-
-        The permanency of the override. Required, one of: follow_schedule,
-        advanced_override (until next scheduled setpoint), temporary_override (must
-        specify duration or until), or permanent_override (indefinitely).
+      # Zone Mode
       default: follow_schedule
       example: advanced_override
       required: true
@@ -307,10 +219,6 @@ set_zone_mode:
             - temporary_override
 
     setpoint:
-      name: Setpoint
-      description: >-
-        The target temperature in degrees Celsius. Required by all modes except for
-        follow_schedule. There is no default value.
       example: 19.5
       selector:
         number:
@@ -321,9 +229,6 @@ set_zone_mode:
           mode: slider
 
     duration:
-      name: Duration
-      description: >-
-        The duration of the temporary_override. Mutually exclusive with until.
       default:
         hours: 1
         minutes: 30
@@ -332,25 +237,18 @@ set_zone_mode:
         duration:
 
     until:
-      name: Until
-      description: >-
-        The end of the temporary_override. Mutually exclusive with duration.
       example: '"YYYY-MM-DD HH:MM:SS"'
       selector:
         datetime:
 
 
 set_zone_schedule:
-  name: Set the Weekly schedule of a Zone
-  description: >-
-    Upload the zone's weekly schedule from a portable format.
+  # Set the Weekly schedule of a Zone
 
   fields:
     entity_id: *entity_id_zone
 
     schedule:
-      name: Schedule
-      description: The weekly schedule of the zone in JSON format.
       required: true
       selector:
         text:
@@ -361,18 +259,13 @@ set_zone_schedule:
 # evohome DHW service calls (CH/DHW)
 
 get_dhw_schedule:
-  name: Get the Weekly schedule of a DHW
-  description: >-
-    Obtains the DHW's latest weekly schedule from the controller and updates the
-    entity's state attributes with that data.
-
-    The schedule will be available at:
-    `{{ state_attr('water_heater.stored_hw', 'schedule') }}`
+  # Get the Weekly schedule of a DHW
 
   fields:
     entity_id: &entity_id_dhw
-      name: Stored DHW
-      description: The entity_id of the stored DHW.
+      # Stored DHW
+      name: notused but can't be empty
+      description: notused
       example: water_heater.01_123456_hw
       required: true
       selector:
@@ -382,43 +275,34 @@ get_dhw_schedule:
 
 
 reset_dhw_mode:
-  name: Reset the Mode of a DHW
-  description: Reset the operating mode of the system's DHW.
+  # Reset the Mode of a DHW
 
   fields:
     entity_id: *entity_id_dhw
 
 
 reset_dhw_params:
-  name: Reset the Configuration of a DHW
-  description: Reset the configuration of the system's DHW.
+  # Reset the Configuration of a DHW
 
   fields:
     entity_id: *entity_id_dhw
 
 
 set_dhw_boost:
-  name: Start Boost mode for a DHW
-  description: Enable the system's DHW for an hour.
+  # Start Boost mode for a DHW
 
   fields:
     entity_id: *entity_id_dhw
 
 
 set_dhw_mode:
-  name: Set the Mode of a DHW
-  description: >-
-    Set the operating mode of the system's DHW, optionally for a given duration.
+  # Set the Mode of a DHW
 
   fields:
     entity_id: *entity_id_dhw
 
     mode:
-      name: DHW mode
-      description: >-
-        The permanency of the override. Required, one of: follow_schedule,
-        advanced_override (until next scheduled setpoint), temporary_override (see:
-        duration and until), or permanent_override (indefinitely).
+      # DHW mode
       default: follow_schedule
       example: advanced_override
       required: true
@@ -432,19 +316,12 @@ set_dhw_mode:
             - temporary_override
 
     active:
-      name: DHW state
-      description: >-
-        The state of the water heater. If active is true, the system will heat the
-        water until the current temperature exceeds the target setpoint. Required by
-        all modes except for follow_schedule. There is no default value.
+      # DHW state
       example: true
       selector:
         boolean:
 
     duration:
-      name: Duration
-      description: >-
-        The duration of the temporary_override. Mutually exclusive with until.
       default:
         hours: 1
         minutes: 30
@@ -453,25 +330,18 @@ set_dhw_mode:
         duration:
 
     until:
-      name: Until
-      description: >-
-        The end of the temporary_override. Mutually exclusive with duration.
       example: '"YYYY-MM-DD HH:MM:SS"'
       selector:
         datetime:
 
 
 set_dhw_params:
-  name: Set the Configuration of a DHW
-  description: Set the configuration of the system's DHW.
+  # Set the Configuration of a DHW
 
   fields:
     entity_id: *entity_id_dhw
 
     setpoint:
-      name: Setpoint
-      description: >-
-        The target temperature in degrees Celsius. Default is 50.0.
       example: 50.0
       selector:
         number:
@@ -482,22 +352,15 @@ set_dhw_params:
           mode: slider
 
     overrun:
-      name: Overrun
-      description: >-
-        The overrun in minutes. Default is 5.
       example: 5
       selector:
         number:
           min: 0
           max: 5
           step: 0.5
-          unit_of_measurement: mins
           mode: slider
 
     differential:
-      name: Differential
-      description: >-
-        The differential in degrees Celsius. Default is 1.0.
       example: 1
       selector:
         number:
@@ -509,16 +372,12 @@ set_dhw_params:
 
 
 set_dhw_schedule:
-  name: Set the Weekly schedule of a DHW
-  description: >-
-    Upload the DHW's weekly schedule from a portable format.
+  # Set the Weekly schedule of a DHW
 
   fields:
     entity_id: *entity_id_dhw
 
     schedule:
-      name: Schedule
-      description: The weekly schedule of the DHW in JSON format.
       required: true
       selector:
         text:
@@ -529,17 +388,13 @@ set_dhw_schedule:
 # faked entity service calls
 
 fake_zone_temp:
-  name: Fake a Room temperature
-  description: >-
-    Set the current temperature (not setpoint) of an evohome zone.
-    This is a convenience wrapper for `put_zone_temp` service call.
+  # Fake a Room temperature
 
   fields:
     entity_id:
-      name: Zone
-      description: >-
-        The entity_id of the evohome zone.
-        Raises an exception if its sensor is not faked (fully-faked, or impersonated).
+      # Zone
+      name: notused but can't be empty
+      description: notused
       example: climate.01_123456_02
       required: true
       selector:
@@ -548,8 +403,6 @@ fake_zone_temp:
           domain: climate
 
     temperature:
-      name: Temperature
-      description: The current temperature in degrees Celsius (not the setpoint).
       required: true
       example: 21.3
       selector:
@@ -562,17 +415,13 @@ fake_zone_temp:
 
 
 fake_dhw_temp:
-  name: Fake a DHW temperature
-  description: >-
-    Set the current temperature (not setpoint) of an evohome water heater.
-    This is a convenience wrapper for the `put_dhw_temp` service call.
+  # Fake a DHW temperature
 
   fields:
     entity_id:
-      name: Stored HW
-      description: >-
-        The entity_id of the evohome water heater.
-        Raises an exception if its sensor is not faked (fully-faked, or impersonated).
+      # Stored HW
+      name: notused but can't be empty
+      description: notused
       example: water_heater.01_123456
       required: true
       selector:
@@ -581,8 +430,6 @@ fake_dhw_temp:
           domain: water_heater
 
     temperature:
-      name: Temperature
-      description: The current temperature in degrees Celsius (not the setpoint).
       required: true
       example: 63.4
       selector:
@@ -598,19 +445,13 @@ fake_dhw_temp:
 # faked sensor service calls
 
 put_room_temp:
-  name: Announce a Room temperature
-  description: >-
-    Announce the measured room temperature of an evohome zone sensor.
-
-    The device must be faked (in the known_list), and should be bound to
-    a CH/DHW controller as a zone sensor.
+  # Announce a Room temperature
 
   fields:
     entity_id:
-      name: Thermostat
-      description: >-
-        The entity_id of the sensor. Raises an exception if it is not faked.
-        Does not raise an exception if not is not bound.
+      # Thermostat
+      name: notused but can't be empty
+      description: notused
       example: sensor.03_123456_temperature
       required: true
       selector:
@@ -620,8 +461,6 @@ put_room_temp:
           device_class: temperature
 
     temperature:
-      name: Temperature
-      description: The current temperature in degrees Celsius (not the setpoint).
       required: true
       example: 21.3
       selector:
@@ -634,19 +473,13 @@ put_room_temp:
 
 
 put_dhw_temp:
-  name: Announce a DHW temperature
-  description: >-
-    Announce the measured temperature of an evohome DHW sensor.
-
-    The device must be faked (in the known_list), and should be bound to
-    a CH/DHW controller as a DHW sensor.
+  # Announce a DHW temperature
 
   fields:
     entity_id:
-      name: Stored DHW
-      description: >-
-        The entity_id of the sensor. Raises an exception if it is not faked.
-        Does not raise an exception if not is not bound.
+      # Stored DHW
+      name: notused but can't be empty
+      description: notused
       example: sensor.07_123456_temperature
       required: true
       selector:
@@ -656,8 +489,6 @@ put_dhw_temp:
           device_class: dhw_temp
 
     temperature:
-      name: Temperature
-      description: The current temperature in degrees Celsius (not the setpoint).
       required: true
       example: 63.4
       selector:
@@ -670,19 +501,12 @@ put_dhw_temp:
 
 
 put_co2_level:
-  name: Announce an Indoor CO2 level
-  description: >-
-    Announce the measured CO2 level of a indoor sensor (experimental).
-
-    The device must be faked (in the known_list), and should be bound to
-    a fan/ventilation unit as a CO2 sensor.
+  # Announce an Indoor CO2 level
 
   fields:
     entity_id:
-      name: Entity_id
-      description: >-
-        The entity_id of the sensor. Raises an exception if it is not faked.
-        Does not raise an exception if not is not bound.
+      name: notused but can't be empty
+      description: notused
       example: sensor.30_123456_co2_level
       required: true
       selector:
@@ -692,8 +516,8 @@ put_co2_level:
           device_class: carbon_dioxide
 
     co2_level:
-      name: CO2 level
-      description: The current CO2 level in ppm.
+      name: notused but can't be empty
+      description: notused
       required: true
       example: 363
       selector:
@@ -706,19 +530,12 @@ put_co2_level:
 
 
 put_indoor_humidity:
-  name: Announce an Indoor relative humidity
-  description: >-
-    Announce the measured relative humidity of a indoor sensor (experimental).
-
-    The device must be faked (in the known_list), and should be bound to
-    a fan/ventilation unit as a humidity sensor.
+  # Announce an Indoor relative humidity
 
   fields:
     entity_id:
-      name: Entity_id
-      description: >-
-        The entity_id of the sensor. Raises an exception if it is not faked.
-        Does not raise an exception if not is not bound.
+      name: notused but can't be empty
+      description: notused
       example: sensor.30_123456_indoor_humidity
       required: true
       selector:
@@ -728,8 +545,8 @@ put_indoor_humidity:
           device_class: humidity
 
     indoor_humidity:
-      name: Indoor humidity
-      description: The current relative humidity as a perecentage (%).
+      name: notused but can't be empty
+      description: notused
       required: true
       example: 59.3
       selector:
@@ -745,17 +562,12 @@ put_indoor_humidity:
 # faked remote service calls
 
 delete_command:
-  name: Delete a Remote command
-  description: >-
-    Deletes a RAMSES command from the database.
-
-    This is a convenience wrapper for HA's own `delete_command` service call.
+  # Delete a Remote command
 
   fields:
     entity_id: &entity_id_remote
-      name: Entity_id
-      description: >-
-        The entity_id of the remote, usually a HVAC device.
+      name: notused but can't be empty
+      description: notused
       required: true
       example: remote.30_123456
       selector:
@@ -764,8 +576,8 @@ delete_command:
           domain: remote
 
     command: &command_remote
-      name: Command name
-      description: The name of the command. Only include a single command at a time.
+      name: notused but can't be empty
+      description: notused
       required: true
       example: Boost
       selector:
@@ -773,12 +585,7 @@ delete_command:
 
 
 learn_command:
-  name: Learn a Remote command
-  description: >-
-    Learns a RAMSES command and adds it to the database.
-
-    This is a convenience wrapper for HA's own `learn_command` service call.
-    The device should be bound to a fan/ventilation unit as a switch.
+  # Learn a Remote command
 
   fields:
     entity_id: *entity_id_remote
@@ -786,14 +593,11 @@ learn_command:
     command: *command_remote
 
     timeout:
-      name: Timeout
-      description: Timeout for the command to be learned.
       required: false
       default: 30
       example: 60
       selector:
         number:
-          unit_of_measurement: seconds
           min: 30
           max: 300
           step: 5
@@ -801,13 +605,7 @@ learn_command:
 
 
 send_command:
-  name: Send a Remote command
-  description: >-
-    Sends a RAMSES command as if from a remote.
-
-    This is a convenience wrapper for HA's own `send_command` service call.
-    The device must be faked (in the known_list), and should be bound to
-    a fan/ventilation unit as a switch.
+  # Send a Remote command
 
   fields:
     entity_id: *entity_id_remote
@@ -815,8 +613,6 @@ send_command:
     command: *command_remote
 
     num_repeats:
-      name: Repeats
-      description: The number of times you want to repeat the command.
       required: false
       default: 3
       example: 3
@@ -828,14 +624,11 @@ send_command:
           mode: slider
 
     delay_secs:
-      name: Delay
-      description: The time you want to wait in between repeated commands.
       required: false
       default: 0.05
       example: 0.05
       selector:
         number:
-          unit_of_measurement: seconds
           min: 0.02
           max: 1.0
           step: 0.01

--- a/custom_components/ramses_cc/translations/en.json
+++ b/custom_components/ramses_cc/translations/en.json
@@ -34,7 +34,7 @@
                     "serial_port": "Advanced serial port config"
                 },
                 "data_description": {
-                  "port_name": "Examples: '/dev/cu.modem2', 'COM6' (Windows) or 'mqtt://user:pwd@homeassistant.local:1883'",
+                  "port_name": "Examples: '/dev/cu.modem2' or 'mqtt://user:pwd@homeassistant.local:1883'",
                     "serial_port": "Not required for typical use."
                 }
             },
@@ -122,7 +122,7 @@
                     "serial_port": "Advanced serial port config"
                 },
                 "data_description": {
-                    "port_name": "Examples: '/dev/cu.modem2', 'COM6' (Windows) or 'mqtt://user:pwd@homeassistant.local:1883'",
+                    "port_name": "Examples: '/dev/cu.modem2' or 'mqtt://user:pwd@homeassistant.local:1883'",
                     "serial_port": "Not required for typical use."
                 }
             },

--- a/custom_components/ramses_cc/translations/en.json
+++ b/custom_components/ramses_cc/translations/en.json
@@ -612,6 +612,14 @@
             "name": "Learn a Remote command",
             "description": "Learns a RAMSES command and adds it to the database. This is a convenience wrapper for HA's own `learn_command` service call. The device should be bound to a fan/ventilation unit as a switch.",
             "fields": {
+                "entity_id": {
+                    "name": "Entity_id",
+                    "description": "The entity_id of the remote, usually a HVAC device."
+                },
+                "command": {
+                    "name": "Command name",
+                    "description": "The name of the command. Only include a single command at a time."
+                },
                 "timeout": {
                     "name": "Timeout",
                     "description": "Timeout for the command to be learned (in seconds)."

--- a/custom_components/ramses_cc/translations/en.json
+++ b/custom_components/ramses_cc/translations/en.json
@@ -242,7 +242,7 @@
 
         "get_system_faults": {
             "name": "Get the Fault log of a TCS (Controller)",
-            "description": "Obtains the controllers's latest fault log entries.",
+            "description": "Obtains the controller's latest fault log entries.",
             "fields": {
                 "entity_id": {
                     "name": "Controller",
@@ -257,13 +257,23 @@
 
         "reset_system_mode": {
             "name": "Fully reset the Mode of a TCS (Controller)",
-            "description": "The system will be in auto mode and all zones will be in follow_schedule mode, including (if supported) those in permanent_override mode."
+            "description": "The system will be in auto mode and all zones will be in follow_schedule mode, including (if supported) those in permanent_override mode.",
+            "fields": {
+                "entity_id": {
+                    "name": "Controller",
+                    "description": "The entity_id of the evohome Controller (TCS, temperature control system). NB: Most of this integration's climate entities are not Controllers (such entities, e.g. zones, will raise an AttributeError)."
+                }
+            }
         },
 
         "set_system_mode": {
             "name": "Set the Mode of a TCS (Controller)",
             "description": "The system will be in the new mode and all zones not in permanent_override mode will be affected. Some modes have the option of a period (of days), others a duration (of hours/minutes).",
             "fields": {
+                "entity_id": {
+                    "name": "Controller",
+                    "description": "The entity_id of the evohome Controller (TCS, temperature control system). NB: Most of this integration's climate entities are not Controllers (such entities, e.g. zones, will raise an AttributeError)."
+                },
                 "mode": {
                     "name": "System Mode",
                     "description": "One of: auto, eco_boost, away, day_off, day_off_eco, heat_off, or custom. All modes can be set indefinitely, some can be set for a period of days, and others for a duration in hours/minutes."
@@ -292,23 +302,45 @@
 
         "put_zone_temp": {
             "name": "Fake the Sensor temperature of a Zone",
-            "description": "Currently deprecated, use `fake_zone_temp` or `put_room_temp` instead."
+            "description": "Currently deprecated, use `fake_zone_temp` or `put_room_temp` instead.",
+            "fields": {
+                "entity_id": {
+                    "name": "Zone",
+                    "description": "The entity_id of the evohome Zone. NB: Some of this integration's climate entities are not Zones (such entities, e.g. Controllers, will raise an AttributeError)."
+                }
+            }
         },
 
         "reset_zone_config": {
             "name": "Reset the Configuration of a Zone",
-            "description": "Reset the configuration of the zone."
+            "description": "Reset the configuration of the zone.",
+            "fields": {
+                "entity_id": {
+                    "name": "Zone",
+                    "description": "The entity_id of the evohome Zone. NB: Some of this integration's climate entities are not Zones (such entities, e.g. Controllers, will raise an AttributeError)."
+                }
+            }
         },
 
         "reset_zone_mode": {
             "name": "Reset the Mode of a Zone",
-            "description": "Reset the operating mode of the zone."
+            "description": "Reset the operating mode of the zone.",
+            "fields": {
+                "entity_id": {
+                    "name": "Zone",
+                    "description": "The entity_id of the evohome Zone. NB: Some of this integration's climate entities are not Zones (such entities, e.g. Controllers, will raise an AttributeError)."
+                }
+            }
         },
 
         "set_zone_config": {
             "name": "Set the Configuration of a Zone",
             "description": "Set the configuration of the zone.",
             "fields": {
+                "entity_id": {
+                    "name": "Zone",
+                    "description": "The entity_id of the evohome Zone. NB: Some of this integration's climate entities are not Zones (such entities, e.g. Controllers, will raise an AttributeError)."
+                },
                 "min_temp": {
                     "name": "Minimum",
                     "description": "The minimum permitted setpoint in degrees Celsius (5-21 °C)."
@@ -324,6 +356,10 @@
             "name": "Set the Mode of a Zone",
             "description": "Set the operating mode of the zone, either indefinitely or for a given duration.",
             "fields": {
+                "entity_id": {
+                    "name": "Zone",
+                    "description": "The entity_id of the evohome Zone. NB: Some of this integration's climate entities are not Zones (such entities, e.g. Controllers, will raise an AttributeError)."
+                },
                 "mode": {
                     "name": "Zone Mode",
                     "description": "The permanency of the override. Required, one of: follow_schedule, advanced_override (until next scheduled setpoint), temporary_override (must specify duration or until), or permanent_override (indefinitely)."
@@ -347,6 +383,10 @@
             "name": "Set the Weekly schedule of a Zone",
             "description": "Upload the zone's weekly schedule from a portable format.",
             "fields": {
+                "entity_id": {
+                    "name": "Zone",
+                    "description": "The entity_id of the evohome Zone. NB: Some of this integration's climate entities are not Zones (such entities, e.g. Controllers, will raise an AttributeError)."
+                },
                 "schedule": {
                     "name": "Schedule",
                     "description": "The weekly schedule of the zone in JSON format."
@@ -367,23 +407,45 @@
 
         "reset_dhw_mode": {
             "name": "Reset the Mode of a DHW",
-            "description": "Reset the operating mode of the system's DHW."
+            "description": "Reset the operating mode of the system's DHW.",
+            "fields": {
+                "entity_id": {
+                    "name": "Stored DHW",
+                    "description": "The entity_id of the stored DHW."
+                }
+            }
         },
 
         "reset_dhw_params": {
             "name": "Reset the Configuration of a DHW",
-            "description": "Reset the configuration of the system's DHW."
+            "description": "Reset the configuration of the system's DHW.",
+            "fields": {
+                "entity_id": {
+                    "name": "Stored DHW",
+                    "description": "The entity_id of the stored DHW."
+                }
+            }
         },
 
         "set_dhw_boost": {
             "name": "Start Boost mode for a DHW",
-            "description": "Enable the system's DHW for an hour."
+            "description": "Enable the system's DHW for an hour.",
+            "fields": {
+                "entity_id": {
+                    "name": "Stored DHW",
+                    "description": "The entity_id of the stored DHW."
+                }
+            }
         },
 
         "set_dhw_mode": {
             "name": "Set the Mode of a DHW",
             "description": "Set the operating mode of the system's DHW, optionally for a given duration.",
             "fields": {
+                "entity_id": {
+                    "name": "Stored DHW",
+                    "description": "The entity_id of the stored DHW."
+                },
                 "mode": {
                     "name": "DHW mode",
                     "description": "The permanency of the override. Required, one of: follow_schedule, advanced_override (until next scheduled setpoint), temporary_override (see: duration and until), or permanent_override (indefinitely)."
@@ -407,6 +469,10 @@
             "name": "Set the Configuration of a DHW",
             "description": "Set the configuration of the system's DHW.",
             "fields": {
+                "entity_id": {
+                    "name": "Stored DHW",
+                    "description": "The entity_id of the stored DHW."
+                },
                 "setpoint": {
                     "name": "Setpoint",
                     "description": "The target temperature in degrees Celsius. Default is 50.0 °C"
@@ -426,6 +492,10 @@
             "name": "Set the Weekly schedule of a DHW",
             "description": "Upload the DHW's weekly schedule from a portable format.",
             "fields": {
+                "entity_id": {
+                    "name": "Stored DHW",
+                    "description": "The entity_id of the stored DHW."
+                },
                 "schedule": {
                     "name": "Schedule",
                     "description": "The weekly schedule of the DHW in JSON format."
@@ -439,7 +509,7 @@
             "fields": {
                 "entity_id": {
                     "name": "Zone",
-                    "description": "The entity_id of the evohome zone. Raises an exception if its sensor is not faked (fully-faked, or impersonated)."
+                    "description": "The entity_id of the evohome zone. Raises an exception if its sensor is not faked (`fully-faked`, or `impersonated`)."
                 },
                 "temperature": {
                     "name": "Temperature",
@@ -454,7 +524,7 @@
             "fields": {
                 "entity_id": {
                     "name": "Stored HW",
-                    "description": "The entity_id of the evohome water heater. Raises an exception if its sensor is not faked (fully-faked, or impersonated)."
+                    "description": "The entity_id of the evohome water heater. Raises an exception if its sensor is not faked (`fully-faked`, or `impersonated`)."
                 },
                 "temperature": {
                     "name": "Temperature",
@@ -469,7 +539,7 @@
             "fields": {
                 "entity_id": {
                     "name": "Thermostat",
-                    "description": "The entity_id of the sensor. Raises an exception if it is not faked. Does not raise an exception if not bound."
+                    "description": "The entity_id of the sensor. Raises an exception if it is not `faked`. Does not raise an exception if not bound."
                 },
                 "temperature": {
                     "name": "Temperature",
@@ -484,7 +554,7 @@
             "fields": {
                 "entity_id": {
                     "name": "Stored DHW",
-                    "description": "The entity_id of the sensor. Raises an exception if it is not faked. Does not raise an exception if not bound."
+                    "description": "The entity_id of the sensor. Raises an exception if it is not `faked`. Does not raise an exception if not bound."
                 },
                 "temperature": {
                     "name": "Temperature",
@@ -499,7 +569,7 @@
             "fields": {
                 "entity_id": {
                     "name": "Entity_id",
-                    "description": "The entity_id of the sensor. Raises an exception if it is not faked. Does not raise an exception if not bound."
+                    "description": "The entity_id of the CO2 sensor. Raises an exception if it is not `faked`. Does not raise an exception if not bound."
                 },
                 "co2_level": {
                     "name": "CO2 level",
@@ -514,7 +584,7 @@
             "fields": {
                 "entity_id": {
                     "name": "Entity_id",
-                    "description": "The entity_id of the sensor. Raises an exception if it is not faked. Does not raise an exception if not bound."
+                    "description": "The entity_id of the RH sensor. Raises an exception if it is not `faked`. Does not raise an exception if not bound."
                 },
                 "indoor_humidity": {
                     "name": "Indoor humidity",

--- a/custom_components/ramses_cc/translations/en.json
+++ b/custom_components/ramses_cc/translations/en.json
@@ -34,7 +34,7 @@
                     "serial_port": "Advanced serial port config"
                 },
                 "data_description": {
-                  "port_name": "Examples: '/dev/cu.modem2' or 'mqtt://user:pwd@homeassistant.local:1883'",
+                  "port_name": "Examples: '/dev/cu.modem2', 'COM6' (Windows) or 'mqtt://user:pwd@homeassistant.local:1883'",
                     "serial_port": "Not required for typical use."
                 }
             },
@@ -122,7 +122,7 @@
                     "serial_port": "Advanced serial port config"
                 },
                 "data_description": {
-                    "port_name": "Examples: '/dev/cu.modem2' or 'mqtt://user:pwd@homeassistant.local:1883'",
+                    "port_name": "Examples: '/dev/cu.modem2', 'COM6' (Windows) or 'mqtt://user:pwd@homeassistant.local:1883'",
                     "serial_port": "Not required for typical use."
                 }
             },
@@ -182,5 +182,395 @@
                 }
             }
         }
+    },
+    "services": {
+
+        "bind_device": {
+            "name": "Bind a Device",
+            "description": "Bind a device to a CH/DHW controller or a fan/ventilation unit. The device will be either a sensor (e.g. temperature, humidity, etc.) or a remote (e.g. a 4-way switch). It must be included in the known_list and correctly configured with an appropriate class and faking enabled.",
+            "fields": {
+                "device_id": {
+                    "name": "Supplicant device_id",
+                    "description": "The device id of the supplicant. Heating (CH/DHW) devices ids must start with a well-known device type. HVAC devices ids should start with a device type that is consistent with their hardware manufacturer's scheme."
+                },
+                "offer": {
+                    "name": "Offer",
+                    "description": "The command_code / domain_idx pairs for the binding offer. If you include '10E0' (device info), ensure the domain id is is set to the hardware manufacturer's oem_code."
+                },
+                "confirm": {
+                    "name": "Confirm",
+                    "description": "The command_code / domain_idx pairs for the binding confirmation, if required."
+                },
+                "device_info": {
+                    "name": "Device info",
+                    "description": "The device_info command of the supplicant (needed to complete some bindings). This is required if you include 10E0 (device info) within the offer. It must be the correct payload for the device class."
+                }
+            }
+        },
+
+        "force_update": {
+            "name": "Update the System state",
+            "description": "Immediately update the system state, without waiting for the next scheduled update."
+        },
+
+        "send_packet": {
+            "name": "Send a Command packet",
+            "description": "Send a completely bespoke RAMSES II command packet from the gateway.",
+            "fields": {
+                "device_id": {
+                    "name": "Destination ID",
+                    "description": "The destination device ID (a RAMSES ID, not an entity_id). Use `18:000730` (a sentinel value) to send a broadcast from the gateway."
+                },
+                "from_id": {
+                    "name": "Source ID",
+                    "description": "The source device ID (a RAMSES ID, not an entity_id). This can be used to send a packet from a faked device. Optional: if not specified, the device ID of the gateway is used."
+                },
+                "verb": {
+                    "name": "Packet verb",
+                    "description": "The packet verb, one of: I, RQ, RP, W (leading space not required)."
+                },
+                "code": {
+                    "name": "Packet code",
+                    "description": "The packet code (class)."
+                },
+                "payload": {
+                    "name": "Payload as hex",
+                    "description": "The packet payload as a hexadecimal string."
+                }
+            }
+        },
+
+        "get_system_faults": {
+            "name": "Get the Fault log of a TCS (Controller)",
+            "description": "Obtains the controllers's latest fault log entries.",
+            "fields": {
+                "entity_id": {
+                    "name": "Controller",
+                    "description": "The entity_id of the evohome Controller (TCS, temperature control system). NB: Most of this integration's climate entities are not Controllers (such entities, e.g. zones, will raise an AttributeError)."
+                },
+                "num_entries": {
+                    "name": "Number of log entries",
+                    "description": "The number of fault log entries to retrieve. Default is 8 entries."
+                }
+            }
+        },
+
+        "reset_system_mode": {
+            "name": "Fully reset the Mode of a TCS (Controller)",
+            "description": "The system will be in auto mode and all zones will be in follow_schedule mode, including (if supported) those in permanent_override mode."
+        },
+
+        "set_system_mode": {
+            "name": "Set the Mode of a TCS (Controller)",
+            "description": "The system will be in the new mode and all zones not in permanent_override mode will be affected. Some modes have the option of a period (of days), others a duration (of hours/minutes).",
+            "fields": {
+                "mode": {
+                    "name": "System Mode",
+                    "description": "One of: auto, eco_boost, away, day_off, day_off_eco, heat_off, or custom. All modes can be set indefinitely, some can be set for a period of days, and others for a duration in hours/minutes."
+                },
+                "period": {
+                    "name": "Period (days)",
+                    "description": "Optional. A period of time in days; valid only with away, day_off, day_off_eco or custom. The system will revert to auto at midnight (up to 99 days, 0 is until midnight tonight)."
+                },
+                "duration": {
+                    "name": "Duration (hours/minutes)",
+                    "description": "Optional. The duration in hours/minutes (up to 24h); valid only with eco_boost."
+                }
+            }
+        },
+
+        "get_zone_schedule": {
+            "name": "Get the Weekly schedule of a Zone",
+            "description": "Obtains the zone's latest weekly schedule from the controller and updates the entity's state attributes with that data. The schedule will be available at: `{{ state_attr('climate.main_room', 'schedule') }}`. Note: only evohome-compatible zones have schedules and not all of this integration's climate entities are such zones (will raise a TypeError).",
+            "fields": {
+                "entity_id": {
+                    "name": "Zone",
+                    "description": "The entity_id of the evohome Zone. NB: Some of this integration's climate entities are not Zones (such entities, e.g. Controllers, will raise an AttributeError)."
+                }
+            }
+        },
+
+        "put_zone_temp": {
+            "name": "Fake the Sensor temperature of a Zone",
+            "description": "Currently deprecated, use `fake_zone_temp` or `put_room_temp` instead."
+        },
+
+        "reset_zone_config": {
+            "name": "Reset the Configuration of a Zone",
+            "description": "Reset the configuration of the zone."
+        },
+
+        "reset_zone_mode": {
+            "name": "Reset the Mode of a Zone",
+            "description": "Reset the operating mode of the zone."
+        },
+
+        "set_zone_config": {
+            "name": "Set the Configuration of a Zone",
+            "description": "Set the configuration of the zone.",
+            "fields": {
+                "min_temp": {
+                    "name": "Minimum",
+                    "description": "The minimum permitted setpoint in degrees Celsius (5-21 °C)."
+                },
+                "max_temp": {
+                    "name": "Maximum",
+                    "description": "The maximum permitted setpoint in degrees Celsius (21-35 °C)."
+                }
+            }
+        },
+
+        "set_zone_mode": {
+            "name": "Set the Mode of a Zone",
+            "description": "Set the operating mode of the zone, either indefinitely or for a given duration.",
+            "fields": {
+                "mode": {
+                    "name": "Zone Mode",
+                    "description": "The permanency of the override. Required, one of: follow_schedule, advanced_override (until next scheduled setpoint), temporary_override (must specify duration or until), or permanent_override (indefinitely)."
+                },
+                "setpoint": {
+                    "name": "Setpoint",
+                    "description": "The target temperature in degrees Celsius. Required by all modes except for follow_schedule. There is no default value."
+                },
+                "duration": {
+                    "name": "Duration",
+                    "description": "The duration of the temporary_override. Mutually exclusive with until."
+                },
+                "until": {
+                    "name": "Until",
+                    "description": "The end of the temporary_override. Mutually exclusive with duration."
+                }
+            }
+        },
+
+        "set_zone_schedule": {
+            "name": "Set the Weekly schedule of a Zone",
+            "description": "Upload the zone's weekly schedule from a portable format.",
+            "fields": {
+                "schedule": {
+                    "name": "Schedule",
+                    "description": "The weekly schedule of the zone in JSON format."
+                }
+            }
+        },
+
+        "get_dhw_schedule": {
+            "name": "Get the Weekly schedule of a DHW",
+            "description": "Obtains the DHW's latest weekly schedule from the controller and updates the entity's state attributes with that data. The schedule will be available at: `{{ state_attr('water_heater.stored_hw', 'schedule') }}`",
+            "fields": {
+                "entity_id": {
+                    "name": "Stored DHW",
+                    "description": "The entity_id of the stored DHW."
+                }
+            }
+        },
+
+        "reset_dhw_mode": {
+            "name": "Reset the Mode of a DHW",
+            "description": "Reset the operating mode of the system's DHW."
+        },
+
+        "reset_dhw_params": {
+            "name": "Reset the Configuration of a DHW",
+            "description": "Reset the configuration of the system's DHW."
+        },
+
+        "set_dhw_boost": {
+            "name": "Start Boost mode for a DHW",
+            "description": "Enable the system's DHW for an hour."
+        },
+
+        "set_dhw_mode": {
+            "name": "Set the Mode of a DHW",
+            "description": "Set the operating mode of the system's DHW, optionally for a given duration.",
+            "fields": {
+                "mode": {
+                    "name": "DHW mode",
+                    "description": "The permanency of the override. Required, one of: follow_schedule, advanced_override (until next scheduled setpoint), temporary_override (see: duration and until), or permanent_override (indefinitely)."
+                },
+                "active": {
+                    "name": "DHW state",
+                    "description": "The state of the water heater. If active is true, the system will heat the water until the current temperature exceeds the target setpoint. Required by all modes except for follow_schedule. There is no default value."
+                },
+                "duration": {
+                    "name": "Duration",
+                    "description": "The duration of the temporary_override. Mutually exclusive with until."
+                },
+                "until": {
+                    "name": "Until",
+                    "description": "The end of the temporary_override. Mutually exclusive with duration."
+                }
+            }
+        },
+
+        "set_dhw_params": {
+            "name": "Set the Configuration of a DHW",
+            "description": "Set the configuration of the system's DHW.",
+            "fields": {
+                "setpoint": {
+                    "name": "Setpoint",
+                    "description": "The target temperature in degrees Celsius. Default is 50.0 °C"
+                },
+                "overrun": {
+                    "name": "Overrun",
+                    "description": "The overrun in minutes. Default is 5 minutes"
+                },
+                "differential": {
+                    "name": "Differential",
+                    "description": "The differential in degrees Celsius. Default is 1.0 °C"
+                }
+            }
+        },
+
+        "set_dhw_schedule": {
+            "name": "Set the Weekly schedule of a DHW",
+            "description": "Upload the DHW's weekly schedule from a portable format.",
+            "fields": {
+                "schedule": {
+                    "name": "Schedule",
+                    "description": "The weekly schedule of the DHW in JSON format."
+                }
+            }
+        },
+
+        "fake_zone_temp": {
+            "name": "Fake a Room temperature",
+            "description": "Set the current temperature (not setpoint) of an evohome zone. This is a convenience wrapper for `put_zone_temp` service call.",
+            "fields": {
+                "entity_id": {
+                    "name": "Zone",
+                    "description": "The entity_id of the evohome zone. Raises an exception if its sensor is not faked (fully-faked, or impersonated)."
+                },
+                "temperature": {
+                    "name": "Temperature",
+                    "description": "The current temperature in degrees Celsius (not the setpoint)."
+                }
+            }
+        },
+
+        "fake_dhw_temp": {
+            "name": "Fake a DHW temperature",
+            "description": "Set the current temperature (not setpoint) of an evohome water heater. This is a convenience wrapper for the `put_dhw_temp` service call.",
+            "fields": {
+                "entity_id": {
+                    "name": "Stored HW",
+                    "description": "The entity_id of the evohome water heater. Raises an exception if its sensor is not faked (fully-faked, or impersonated)."
+                },
+                "temperature": {
+                    "name": "Temperature",
+                    "description": "The current temperature in degrees Celsius (not the setpoint)."
+                }
+            }
+        },
+
+        "put_room_temp": {
+            "name": "Announce a Room temperature",
+            "description": "Announce the measured room temperature of an evohome zone sensor. The device must be faked (in the known_list), and should be bound to a CH/DHW controller as a zone sensor.",
+            "fields": {
+                "entity_id": {
+                    "name": "Thermostat",
+                    "description": "The entity_id of the sensor. Raises an exception if it is not faked. Does not raise an exception if not bound."
+                },
+                "temperature": {
+                    "name": "Temperature",
+                    "description": "The current temperature in degrees Celsius (not the setpoint)."
+                }
+            }
+        },
+
+        "put_dhw_temp": {
+            "name": "Announce a DHW temperature",
+            "description": "Announce the measured temperature of an evohome DHW sensor. The device must be faked (in the known_list), and should be bound to a CH/DHW controller as a DHW sensor.",
+            "fields": {
+                "entity_id": {
+                    "name": "Stored DHW",
+                    "description": "The entity_id of the sensor. Raises an exception if it is not faked. Does not raise an exception if not bound."
+                },
+                "temperature": {
+                    "name": "Temperature",
+                    "description": "The current temperature in degrees Celsius (not the setpoint)."
+                }
+            }
+        },
+
+        "put_co2_level": {
+            "name": "Announce an Indoor CO2 level",
+            "description": "Announce the measured CO2 level of a indoor sensor (experimental). The device must faked (in the known_list), and should be bound to a fan/ventilation unit as a CO2 sensor.",
+            "fields": {
+                "entity_id": {
+                    "name": "Entity_id",
+                    "description": "The entity_id of the sensor. Raises an exception if it is not faked. Does not raise an exception if not bound."
+                },
+                "co2_level": {
+                    "name": "CO2 level",
+                    "description": "The current CO2 level in ppm."
+                }
+            }
+        },
+
+        "put_indoor_humidity": {
+            "name": "Announce an Indoor relative humidity",
+            "description": "Announce the measured relative humidity of a indoor sensor (experimental). The device must be faked (in the known_list), and should be bound to a fan/ventilation unit as a humidity sensor.",
+            "fields": {
+                "entity_id": {
+                    "name": "Entity_id",
+                    "description": "The entity_id of the sensor. Raises an exception if it is not faked. Does not raise an exception if not bound."
+                },
+                "indoor_humidity": {
+                    "name": "Indoor humidity",
+                    "description": "The current relative humidity as a percentage (%)."
+                }
+            }
+        },
+
+        "delete_command": {
+            "name": "Delete a Remote command",
+            "description": "Deletes a RAMSES command from the database. This is a convenience wrapper for HA's own `delete_command` service call.",
+            "fields": {
+                "entity_id": {
+                    "name": "Entity_id",
+                    "description": "The entity_id of the remote, usually a HVAC device."
+                },
+                "command": {
+                    "name": "Command name",
+                    "description": "The name of the command. Only include a single command at a time."
+                }
+            }
+        },
+
+        "learn_command": {
+            "name": "Learn a Remote command",
+            "description": "Learns a RAMSES command and adds it to the database. This is a convenience wrapper for HA's own `learn_command` service call. The device should be bound to a fan/ventilation unit as a switch.",
+            "fields": {
+                "timeout": {
+                    "name": "Timeout",
+                    "description": "Timeout for the command to be learned (in seconds)."
+                }
+            }
+        },
+
+        "send_command": {
+            "name": "Send a Remote command",
+            "description": "Sends a RAMSES command as if from a remote. This is a convenience wrapper for HA's own `send_command` service call. The device must be faked (in the known_list), and should be bound to a fan/ventilation unit as a switch.",
+            "fields": {
+                "entity_id": {
+                    "name": "Entity_id",
+                    "description": "The entity_id of the remote, usually a HVAC device."
+                },
+                "command": {
+                    "name": "Command name",
+                    "description": "The name of the command. Only include a single command at a time."
+                },
+                "num_repeats": {
+                    "name": "Repeats",
+                    "description": "The number of times you want to repeat the command."
+                },
+                "delay_secs": {
+                    "name": "Delay",
+                    "description": "The time you want to wait in between repeated commands (in seconds)."
+                }
+            }
+        }
+
     }
 }

--- a/custom_components/ramses_cc/translations/nl.json
+++ b/custom_components/ramses_cc/translations/nl.json
@@ -1,11 +1,11 @@
 {
     "config": {
         "abort": {
-            "single_instance_allowed": "Al geconfigureerd. Slechts één configuratie wordt ondersteund."
+            "single_instance_allowed": "Ramses RF is al geconfigureerd. Slechts één configuratie wordt ondersteund."
         },
         "error": {
             "invalid_gateway_config": "Ongeldige ramses_rf configuratie: {error_detail}",
-            "invalid_port_config": "Ongeldige seriële poort-configuratie: {error_detail}",
+            "invalid_port_config": "Ongeldige seriële-poortconfiguratie: {error_detail}",
             "invalid_regex": "Ongeldige reguliere expressie: {error_detail}",
             "invalid_schema": "Ongeldig schema: {error_detail}",
             "invalid_traits": "Ongeldige device-kenmerken: {error_detail}"
@@ -24,18 +24,18 @@
             "choose_serial_port": {
                 "title": "Selecteer de seriële poort",
                 "data": {
-                    "port_name": "Serieel "
+                    "port_name": "Pad naar seriële poort"
                 }
             },
             "configure_serial_port": {
-                "title": "Seriële poort-instellingen",
+                "title": "Seriële-poortinstellingen",
                 "data": {
-                    "port_name": "Pad naar serieel device",
+                    "port_name": "Pad naar serieel apparaat",
                     "serial_port": "Geavanceerde instellingen seriële poort"
                 },
                 "data_description": {
-                    "port_name": "Bijv. '/dev/cu.modem2' of 'mqtt://user:pwd@homeassistant.local:1883'",
-                    "serial_port": "Normaal niet nodig."
+                    "port_name": "Bijv. '/dev/cu.modem2', 'COM6' (Windows) of 'mqtt://user:pwd@homeassistant.local:1883'",
+                    "serial_port": "Voor standaardgebruik niet vereist."
                 }
             },
             "config": {
@@ -45,8 +45,8 @@
                     "ramses_rf": "Geavanceerde instellingen ramses_rf gateway"
                 },
                 "data_description": {
-                    "scan_interval": "Hoe vaak pollen voor wijzigingen in toestand? Advies: waarde tussen 60 en 180s.",
-                    "ramses_rf": "Normaal niet nodig."
+                    "scan_interval": "Hoe vaak opvragen (pollen) voor wijzigingen? Advies: waarde tussen 60 en 180 s.",
+                    "ramses_rf": "Voor standaardgebruik niet vereist."
                 }
             },
             "schema": {
@@ -54,35 +54,35 @@
                 "description": "Zie voor meer info en voorbeelden de [wiki](https://github.com/zxdavb/ramses_cc/wiki/) onder het kopje Configuration.",
                 "data": {
                     "schema": "Systeemschema(s)",
-                    "known_list": "Erkende device ID's",
-                    "enforce_known_list": "Accepteer alleen packets van erkende device ID's"
+                    "known_list": "Erkende device_id's",
+                    "enforce_known_list": "Accepteer alleen berichten van erkende device ID's"
                 },
                 "data_description": {
                     "schema": "Een mapping van systeem device-ID's naar hun schema's. Houd dit eenvoudig en vermeld alleen devices die niet automatisch verschijnen.",
                     "known_list": "Een mapping van erkende device-ID's en (optioneel) hun kenmerken.",
-                    "enforce_known_list": "Aanbevolen zodra alle device-ID's zijn ingevuld, omdat het RAMSES II-protocol geen foutcorrectie biedt en corrupte device-ID's vaak voorkomen."
+                    "enforce_known_list": "Aanbevolen om in te schakelen zodra alle device_id's zijn ingevuld,. Het RAMSES II-protocol biedt namelijk geen foutcorrectie en corrupte device_id's komen vaak voor."
                 }
             },
             "advanced_features": {
                 "title": "Geavanceerde opties",
                 "data": {
-                    "send_packet": "Schakel send_packet service in om maatwerkpakketjes te broadcasten",
+                    "send_packet": "Schakel `send_packet service` in om maatwerkberichten (bytes) te broadcasten",
                     "message_events": "Zend events voor berichten die aan de reguliere expressie voldoen"
                 },
                 "data_description": {
-                    "message_events": "Vul een reguliere expressie in waar berichten aan moeten voldoen, bijv. `RP.* 10:` zal events sturen voor alle berichten van een OTB."
+                    "message_events": "Vul een reguliere expressie in waaraan berichten moeten voldoen, bijv. `RP.* 10:` = events sturen voor alle berichten van een OTB."
                 }
             },
             "packet_log": {
                 "title": "Packet-log",
-                "description": "Optioneel packet-log voor oplossen van problemen en ontwikkeling van de integratie.",
+                "description": "Optioneel packet-logbestand voor probleemoplossing en doorontwikkeling van de ramses_rf integratie.",
                 "data": {
                     "file_name": "Bestandsnaam packet-log",
-                    "rotate_bytes": "Maximumgrootte van elk packet-log",
+                    "rotate_bytes": "Maximumgrootte per packet-log",
                     "rotate_backups": "Aantal te bewaren packet-logs"
                 },
                 "data_description": {
-                    "file_name": "Pad naar het packet-logbestand. Bewaarde backups gebruiken de bestandsnaam + een achtervoegsel."
+                    "file_name": "Pad naar het packet-logbestand. Bewaarde backups krijgen deze bestandsnaam + een achtervoegsel."
                 }
             }
         }
@@ -112,18 +112,18 @@
             "choose_serial_port": {
                 "title": "Selecteer een seriële poort",
                 "data": {
-                    "port_name": "Pad naar serieel device"
+                    "port_name": "Pad naar serieel apparaat"
                 }
             },
             "configure_serial_port": {
-                "title": "Seriële poort-configuratie",
+                "title": "Seriële-poortconfiguratie",
                 "data": {
-                    "port_name": "Pad naar serieel device",
-                    "serial_port": "Geavanceerde seriële poort-configuratie"
+                    "port_name": "Pad naar serieel apparaat",
+                    "serial_port": "Geavanceerde seriële-poortconfiguratie"
                 },
                 "data_description": {
-                    "port_name": "Bijv. '/dev/cu.modem2' of 'mqtt://user:pwd@homeassistant.local:1883'",
-                    "serial_port": "Normaal niet nodig."
+                    "port_name": "Bijv. '/dev/cu.modem2', 'COM6' of 'mqtt://user:pwd@homeassistant.local:1883'",
+                    "serial_port": "Voor standaardgebruik niet vereist."
                 }
             },
             "config": {
@@ -133,17 +133,17 @@
                     "ramses_rf": "Geavanceerde ramses_rf gateway-configuratie"
                 },
                 "data_description": {
-                    "scan_interval": "Hoe vaak pollen voor wijzigingen in toestand? Advies: waarde tussen 60 en 180s.",
-                    "ramses_rf": "Normaal niet nodig."
+                    "scan_interval": "Hoe vaak opvragen (pollen) voor wijzigingen? Advies: waarde tussen 60 en 180s.",
+                    "ramses_rf": "Voor standaardgebruik niet vereist."
                 }
             },
             "schema": {
-                "title": "Systeemschema en erkende devices",
+                "title": "Systeemschema en erkende apparaten",
                 "description": "Zie voor meer info en voorbeelden de [wiki](https://github.com/zxdavb/ramses_cc/wiki/) onder het kopje Configuration.",
                 "data": {
                     "schema": "Systeemschema('s)",
-                    "known_list": "Erkende device ID's",
-                    "enforce_known_list": "Accepteer alleen packets van erkende device ID's"
+                    "known_list": "Erkende device_id's",
+                    "enforce_known_list": "Accepteer alleen berichten van erkende device ID's"
                 },
                 "data_description": {
                     "schema": "Een mapping van systeem device-ID's naar hun schema's. Houd dit eenvoudig en vermeld alleen devices die niet automatisch verschijnen.",
@@ -154,7 +154,7 @@
             "advanced_features": {
                 "title": "Geavanceerde opties",
                 "data": {
-                    "send_packet": "Schakel send_packet service in om maatwerk-packets te zenden",
+                    "send_packet": "Schakel send_packet service in om maatwerk-berichten te versturen",
                     "message_events": "Stuur events voor berichten die voldoen aan een reguliere expressie"
                 },
                 "data_description": {
@@ -162,25 +162,415 @@
                 }
             },
             "packet_log": {
-                "title": "Packet-log",
-                "description": "Optioneel packet-log voor oplossen van problemen en ontwikkeling van de integratie.",
+                "title": "Berichten-logboek",
+                "description": "Optioneel berichten-logbestand voor oplossen van problemen en ontwikkeling van de integratie.",
                 "data": {
-                    "file_name": "Bestandsnaam packet-log",
-                    "rotate_bytes": "Maximumgrootte van elk packet-log",
-                    "rotate_backups": "Aantal te bewaren packet-logs"
+                    "file_name": "Bestandsnaam berichten-logbestanden",
+                    "rotate_bytes": "Maximumgrootte van elk berichten-logbestanden",
+                    "rotate_backups": "Aantal te bewaren berichten-logbestanden"
                 },
                 "data_description": {
-                    "file_name": "Pad naar het packet-logbestand. Bewaarde backups gebruiken de bestandsnaam + een achtervoegsel."
+                    "file_name": "Pad naar het berichten-logbestand. Bewaarde backups gebruiken deze naam + een achtervoegsel."
                 }
             },
             "clear_cache": {
                 "title": "Cache beheren",
-                "description": "Selecteer hieronder welke caches direct gewist moeten worden en herlaad dan de integratie bij grote veranderingen in het systeemschema of de configuratie.",
+                "description": "De geselecteerde caches worden direct gewist als je op [VERZENDEN] klikt. Herlaad daarna de integratie na grote aanpassingen in het systeemschema of de configuratie. Beide schuifjes naar links = niets wissen",
                 "data": {
                     "clear_schema": "Wis ontdekte systeemschema('s)",
-                    "clear_packets": "Wis systeemtoestand (recente packets)"
+                    "clear_packets": "Wis systeemtoestand (recente berichten)"
                 }
             }
         }
+    },
+    "services": {
+
+        "bind_device": {
+            "name": "Koppel een apparaat",
+            "description": "Koppel een apparaat aan een CH/DHW controller of aan een fan/WTW-eenheid. Het te koppelen apparaat is een sensor (bijv. temperatuur, relatieve vochtigheid, etc.) of een afstandsbediening (bijv. een 4-knops RF-schakelaar). En het moet vermeld staan in de `known_list`, correct geconfigureerd met de juiste apparaat-klasse en met `faking` ingeschakeld.",
+            "fields": {
+                "device_id": {
+                    "name": "Device_id van het apparaat",
+                    "description": "Device_id van het te koppelen apparaat. ID's van Verwarmingsapparaten (CH/DHW) moeten beginnen met een `well-known device type`. ID's van HVAC-apparaten moeten beginnen met een type dat past bij het schema van de fabrikant."
+                },
+                "offer": {
+                    "name": "Aanbod",
+                    "description": "De `commando_code` / `domain_idx` paren van het koppel-verzoek. Als de code '10E0' (device info) wordt gebruikt, zorg dan dat `domain_idx` overeenkomt met de `oem_code` van de fabrikant."
+                },
+                "confirm": {
+                    "name": "Bevestiging",
+                    "description": "De `commando_code` / `domain_idx` bericht-combinaties om de koppeling te bevestigen, indien vereist."
+                },
+                "device_info": {
+                    "name": "Apparaat-info",
+                    "description": "Het `device_info` commando van de aanvrager (voor sommige koppelingen vereist). Vereist als `10E0` (device info) in het koppelverzoek voorkomt. Dit moet de juiste `payload` zijn voor de apparaat-klasse."
+                }
+            }
+        },
+
+        "force_update": {
+            "name": "Werk systeemstatus bij",
+            "description": "Werk nu de systeemstatus bij i.p.v. wachten tot de eerstvolgende geplande update."
+        },
+
+        "send_packet": {
+            "name": "Verstuur een maatwerkbericht",
+            "description": "Verstuur een op maat gemaakt RAMSES II commando-bericht (bytes) vanaf de gateway/dongel.",
+            "fields": {
+                "device_id": {
+                    "name": "Bestemming",
+                    "description": "Apparaat ID (een RAMSES ID, geen entity_id) waar het bericht naartoe gestuurd wordt. Gebruik `18:000730` (een algemene waarde) om vanaf de gateway een `broadcast` te sturen naar alle apparaten."
+                },
+                "from_id": {
+                    "name": "Bron",
+                    "description": "Apparaat ID (een RAMSES ID, geen entity_id) dat als verzender van het bericht geldt. Gebruik dit om een bericht vanaf een geïmiteerd (`faked`) apparaat te versturen. Optioneel: als dit veld leeg is, wordt het apparaat ID van de gateway als afzender gebruikt."
+                },
+                "verb": {
+                    "name": "Opdracht-code",
+                    "description": "De opdracht-code (`verb`) van het bericht: I, RQ, RP of W (voorloop-spatie voor I en W niet nodig)."
+                },
+                "code": {
+                    "name": "Bericht-code",
+                    "description": "De Bericht-code (klasse)."
+                },
+                "payload": {
+                    "name": "Inhoud als HEX",
+                    "description": "De inhoud (`payload`) als hexadecimale string."
+                }
+            }
+        },
+
+        "get_system_faults": {
+            "name": "Haal foutenlog van een TCS (Controller) op",
+            "description": "Verzamelt het meest recente foutenlog van een Controller.",
+            "fields": {
+                "entity_id": {
+                    "name": "Controller",
+                    "description": "Entity_id van de evohome Controller (TCS, Temperature Control System). NB: De meeste HVAC-apparaten in ramses_rf zijn geen Controllers (zulke apparaten, bijv. zones, zullen een fout `AttributeError` melden)."
+                },
+                "num_entries": {
+                    "name": "Aantal logberichten",
+                    "description": "Het aantal op te halen foutmeldingen. Standaard: 8 meldingen."
+                }
+            }
+        },
+
+        "reset_system_mode": {
+            "name": "Reset TCS (Controller)",
+            "description": "Het systeem gaat in `Auto` modus en alle zones gaan naar `follow_schedule` modus, incl. (voor zover ondersteund) zones die nu in `permanent_override` modus staan."
+        },
+
+        "set_system_mode": {
+            "name": "Stel modus van een TCS (Controller) in",
+            "description": "Het systeem gaat in de nieuwe modus en alle zones die nu niet in `permanent_override` modus staan worden aangepast. Sommige modi bevatten de optie om een periode (dagen), of een duur (uren/minuten) mee te geven.",
+            "fields": {
+                "mode": {
+                    "name": "Systeem-modus",
+                    "description": "Kies uit: auto, eco_boost, away, day_off, day_off_eco, heat_off, of custom. Alle modi kunnen permanent ingeschakeld worden, sommige voor een periode (in dagen), en andere voor een bepaalde tijd (in uren/minuten)"
+                },
+                "period": {
+                    "name": "Periode (dagen)",
+                    "description": "Optioneel. Een tijdsperiode in dagen; alleen geldig met de modi: away, day_off, day_off_eco of custom. Het systeem gaat terug naar auto om middernacht (tot 99 dagen, 0 is tot vannacht 0:00 uur)."
+                },
+                "duration": {
+                    "name": "Gedurende (uren/minuten)",
+                    "description": "Optioneel. Duur in uren/minuten (tot max. 24u); alleen geldig met modus: eco_boost."
+                }
+            }
+        },
+
+        "get_zone_schedule": {
+            "name": "Haal weekschema van een Zone op",
+            "description": "Leest het laatste weekschema van een zone uit de Controller en werkt met die data de device-status bij. Het weekschema is op te vragen als: `{{ state_attr('climate.main_room', 'schedule') }}`. Noot: alleen evohome-compatibele zones hebben een weekschema en in Ramses RF hebben niet alle klimaat-entiteiten zulke zones (er volgt een `TypeError`).",
+            "fields": {
+                "entity_id": {
+                    "name": "Zone",
+                    "description": "De entity_id van de evohome Zone. NB: in Ramses RF zijn sommige klimaat-entiteiten geen zones (zij zullen een `AttributeError` geven)."
+                }
+            }
+        },
+
+        "put_zone_temp": {
+            "name": "Imiteer sensortemperatuur van een Zone",
+            "description": "Niet mee gebruikt. Gebruik `fake_zone_temp` of `put_room_temp`."
+        },
+
+        "reset_zone_config": {
+            "name": "Reset Configuratie van een Zone",
+            "description": "Reset de configuratie van de zone."
+        },
+
+        "reset_zone_mode": {
+            "name": "Reset Modus van een Zone",
+            "description": "Reset de werkmodus van de zone."
+        },
+
+        "set_zone_config": {
+            "name": "Stel Configuratie van een Zone in",
+            "description": "Stel de configuratie van de zone in als:",
+            "fields": {
+                "min_temp": {
+                    "name": "Minimum",
+                    "description": "Het laagst mogelijke instelpunt in graden Celsius (5-21 °C)."
+                },
+                "max_temp": {
+                    "name": "Maximum",
+                    "description": "Het hoogst mogelijke instelpunt in graden Celsius (21-35 °C)."
+                }
+            }
+        },
+
+        "set_zone_mode": {
+            "name": "Stel Modus van een Zone in",
+            "description": "Stel de werkmodus van de zone in, permanent of voor een bepaalde periode.",
+            "fields": {
+                "mode": {
+                    "name": "Zone-modus",
+                    "description": "Hoe lang is de aanpassing geldig? Kies uit: `follow_schedule`, `advanced_override` (tot vlg. geplande instelling), `temporary_override` (vul hiervoor ook de duur of tot-moment in), of `permanent_override` (vanaf nu)."
+                },
+                "setpoint": {
+                    "name": "Instelpunt",
+                    "description": "De doeltemperatuur in graden Celsius. Is vereist voor alle modi behalve `follow_schedule`. Er is geen standaardwaarde."
+                },
+                "duration": {
+                    "name": "Duur",
+                    "description": "Hoe lang de `temporary_override` van kracht is. Niet tegelijk met `Tot` toepasbaar."
+                },
+                "until": {
+                    "name": "Tot",
+                    "description": "Eindmoment van de `temporary_override`. Niet tegelijk met `Duur` toepasbaar."
+                }
+            }
+        },
+
+        "set_zone_schedule": {
+            "name": "Stel weekschema van een Zone in",
+            "description": "Upload het weekschema voor een zone in JSON formaat.",
+            "fields": {
+                "schedule": {
+                    "name": "Weekschema",
+                    "description": "Nieuw weekschema voor een zone, in JSON format."
+                }
+            }
+        },
+
+        "get_dhw_schedule": {
+            "name": "Haal weekschema warmtapwater op",
+            "description": "Leest het laatste weekschema van een warmtapwaterapparaat op en werkt met die data de device-status bij. Het weekschema is op te vragen als:: `{{ state_attr('water_heater.stored_hw', 'schedule') }}`",
+            "fields": {
+                "entity_id": {
+                    "name": "Opgeslagen DHW",
+                    "description": "Entity_id van de opgeslagen DHW."
+                }
+            }
+        },
+
+        "reset_dhw_mode": {
+            "name": "Reset Modus Warmtapwater",
+            "description": "Reset de werkmodus van een warmtapwaterapparaat."
+        },
+
+        "reset_dhw_params": {
+            "name": "Reset de Configuratie Warmtapwater",
+            "description": "Reset the configuratie van een warmtapwaterapparaat."
+        },
+
+        "set_dhw_boost": {
+            "name": "Boost Warmtapwater",
+            "description": "Activeer een warmtapwaterapparaat voor 1 uur."
+        },
+
+        "set_dhw_mode": {
+            "name": "Stel Modus voor Warmtapwater in",
+            "description": "Stel de werkmodus van een warmtapwaterapparaat in, optioneel voor een bepaalde tijd.",
+            "fields": {
+                "mode": {
+                    "name": "Warmwater-modus",
+                    "description": "Hoe lang is de aanpassing geldig? Kies uit: `follow_schedule`, `advanced_override` (tot vlg. geplande instelling), `temporary_override` (vul hiervoor ook de duur of tot-moment in), of `permanent_override` (vanaf nu)."
+                },
+                "active": {
+                    "name": "Warmwater-status",
+                    "description": "Status voor warmwater. Als de status `active` is, zal het water opgewarmd worden tot de temperatuur hoger is dan het ingestelde maximum. Is vereist voor alle modi behalve `follow_schedule`. Er is geen standaardwaarde."
+                },
+                "duration": {
+                    "name": "Duur",
+                    "description": "Hoe lang de `temporary_override` van kracht is. Niet tegelijk met `Tot` toepasbaar."
+                },
+                "until": {
+                    "name": "Tot",
+                    "description": "Eindmoment van de `temporary_override`. Niet tegelijk met `Duur` toepasbaar."
+                }
+            }
+        },
+
+        "set_dhw_params": {
+            "name": "Stel Configuratie van Warmtapwater in",
+            "description": "Instellingen voor warmtapwater-apparaat.",
+            "fields": {
+                "setpoint": {
+                    "name": "Instelpunt",
+                    "description": "Doeltemperatuur in ˚C. Standaardwaarde is 50.0"
+                },
+                "overrun": {
+                    "name": "Overrun",
+                    "description": "Overrun in minuten. Standaardwaarde: 5 min"
+                },
+                "differential": {
+                    "name": "Afwijking",
+                    "description": "Afwijking in ˚C. Standaardwaarde is 1,0˚C"
+                }
+            }
+        },
+
+        "set_dhw_schedule": {
+            "name": "Stel weekschema Warmtapwater in",
+            "description": "Upload het weekschema voor Warmtapwaterverwarming in JSON formaat.",
+            "fields": {
+                "schedule": {
+                    "name": "Weekschema",
+                    "description": "Nieuw weekschema voor Warmtapwaterverwarming, in JSON-formaat."
+                }
+            }
+        },
+
+        "fake_zone_temp": {
+            "name": "Simuleer Kamertemperatuur",
+            "description": "Stel een nieuwe ruimtetemperatuur in (niet het instelpunt) voor een evohome zone. Dit is een makkelijke versie van de `Meld Ruimtetemperatuur` actie.",
+            "fields": {
+                "entity_id": {
+                    "name": "Zone",
+                    "description": "Entity_id van de evohome zone. Geeft een foutmelding als de sensor niet als `fully-faked` of `impersonated` in de `known_list` is vermeld."
+                },
+                "temperature": {
+                    "name": "Temperatuur",
+                    "description": "Nieuwe temperatuur in ˚C (niet de ingestelde temp.)."
+                }
+            }
+        },
+
+        "fake_dhw_temp": {
+            "name": "Simuleer warmtapwater-temperatuur",
+            "description": "Stel een nieuwe watertemperatuur in (niet het instelpunt) voor een evohome warmtapwaterapparaat. Dit is een makkelijke versie van de `Meld Warmtapwatertemperatuur` actie.",
+            "fields": {
+                "entity_id": {
+                    "name": "Warmwatervoorraad",
+                    "description": "Entity_id van het evohome warmtapwaterapparaat. Geeft een foutmelding als de sensor niet als `fully-faked` of `impersonated` in de `known_list` is vermeld."
+                },
+                "temperature": {
+                    "name": "Temperatuur",
+                    "description": "Nieuwe temperatuur in ˚C (niet de ingestelde temp.)."
+                }
+            }
+        },
+
+        "put_room_temp": {
+            "name": "Meld Ruimtetemperatuur",
+            "description": "Stel een nieuwe ruimtetemperatuur in (niet het instelpunt) voor een evohome zone thermostaat. De thermostaat moet als `faked` in de `known_list` staan, en als zone-sensor zijn gekoppeld aan een Verwarming/Warmtapwater-controller.",
+            "fields": {
+                "entity_id": {
+                    "name": "Thermostaat",
+                    "description": "Entity_id van de sensor. Geeft een foutmelding als de sensor niet `faked` is. Geeft geen foutmelding als hij niet is gekoppeld (maar zal dan niet werken)."
+                },
+                "temperature": {
+                    "name": "Temperatuur",
+                    "description": "Nieuwe temperatuur in ˚C (niet de ingestelde)."
+                }
+            }
+        },
+
+        "put_dhw_temp": {
+            "name": "Meld Warmtapwatertemperatuur",
+            "description": "Stel een nieuwe temperatuur in voor een evohome warmwater-sensor. De sensor moet als `faked` in de `known_list` staan, en als warmwater-sensor zijn gekoppeld aan een Verwarming/Warmtapwater-controller.",
+            "fields": {
+                "entity_id": {
+                    "name": "Warmwatervoorraad",
+                    "description": "Entity_id van de sensor. Geeft een foutmelding als de sensor niet `faked` is. Geeft geen foutmelding als hij niet is gekoppeld (maar zal dan niet werken)."
+                },
+                "temperature": {
+                    "name": "Temperatuur",
+                    "description": "Nieuwe temperatuur in ˚C (niet de ingestelde)."
+                }
+            }
+        },
+
+        "put_co2_level": {
+            "name": "Meld CO2-waarde",
+            "description": "Stel een nieuwe CO2-waarde in voor een ruimtesensor (experimenteel). De sensor moet als `faked` in de `known_list` staan, en als CO2-sensor zijn gekoppeld aan een fan/ventilatie-eenheid.",
+            "fields": {
+                "entity_id": {
+                    "name": "Entity_id",
+                    "description": "Entity_id van de sensor. Geeft een foutmelding als de sensor niet `faked` is. Geeft geen foutmelding als hij niet is gekoppeld (maar zal dan niet werken)."
+                },
+                "co2_level": {
+                    "name": "CO2-niveau",
+                    "description": "Nieuw CO2-niveau (in ppm)."
+                }
+            }
+        },
+
+        "put_indoor_humidity": {
+            "name": "Meld Relatieve vochtigheid",
+            "description": "Stel een nieuwe waarde in voor de relatieve vochtigheid in een ruimte (experimenteel). De sensor moet als `faked` in de `known_list` staan, en als RV-sensor zijn gekoppeld aan een fan/ventilatie-eenheid.",
+            "fields": {
+                "entity_id": {
+                    "name": "Entity_id",
+                    "description": "Entity_id van de sensor. Geeft een foutmelding als de sensor niet `faked` is. Geeft geen foutmelding als hij niet is gekoppeld (maar zal dan niet werken)."
+                },
+                "indoor_humidity": {
+                    "name": "Relatieve vochtigheid",
+                    "description": "Nieuwe waarde voor relatieve luchtvochtigheid (in %)."
+                }
+            }
+        },
+
+        "delete_command": {
+            "name": "Wis commando van een Afstandsbediening",
+            "description": "Verwijdert een RAMSES commando uit de database. Dit is en makkelijke actie voor HA's eigen `delete_command` actie.",
+            "fields": {
+                "entity_id": {
+                    "name": "Entity_id",
+                    "description": "Entity_id van de afstandsbediening, meestal een HVAC-apparaat."
+                },
+                "command": {
+                    "name": "Command name",
+                    "description": "Naam van het commando. Eén commando per opdracht."
+                }
+            }
+        },
+
+        "learn_command": {
+            "name": "Leer een Afstandsbediening-commando",
+            "description": "Vangt een RAMSES commando op en voegt het toe aan de database. Dit is een makkelijke actie voor HA's eigen `learn_command` actie. De afstandsbediening moet als schakelaar al gekoppeld zijn aan een fan/ventilator.",
+            "fields": {
+                "timeout": {
+                    "name": "Timeout",
+                    "description": "Timeout voor het leren van het commando."
+                }
+            }
+        },
+
+        "send_command": {
+            "name": "Verstuur een Remote commando",
+            "description": "Verstuurt een RAMSES commando alsof afkomstig van een afstandsbediening. Dit is een makkelijke actie voor HA's eigen `send_command` actie. Het apparaat moet in de `known_list` als `faked` staan en als schakelaar zijn gekoppeld aan een fan/ventilatie-unit.",
+            "fields": {
+                "entity_id": {
+                    "name": "Entity_id",
+                    "description": "Entity_id van de afstandsbediening, meestal een HVAC-apparaat."
+                },
+                "command": {
+                    "name": "Commando",
+                    "description": ""
+                },
+                "num_repeats": {
+                    "name": "Herhalen",
+                    "description": "Het aantal keren dat dit commando wordt herhaald."
+                },
+                "delay_secs": {
+                    "name": "Vertraging",
+                    "description": "Pauze tussen herhalingen (in sec.)"
+                }
+            }
+        }
+
     }
 }

--- a/custom_components/ramses_cc/translations/nl.json
+++ b/custom_components/ramses_cc/translations/nl.json
@@ -592,8 +592,8 @@
                     "description": "Entity_id van de afstandsbediening, meestal een HVAC-apparaat."
                 },
                 "command": {
-                    "name": "Command name",
-                    "description": "Naam van het commando. Eén commando per opdracht."
+                    "name": "Commando",
+                    "description": "Naam van het commando. Eén per opdracht."
                 }
             }
         },
@@ -602,6 +602,14 @@
             "name": "Leer Afstandsbediening-commando",
             "description": "Vangt een RAMSES commando op en voegt het toe aan de database. Dit is een makkelijke actie voor HA's eigen `learn_command` actie. De afstandsbediening moet als schakelaar al gekoppeld zijn aan een fan/ventilator.",
             "fields": {
+                "entity_id": {
+                    "name": "Entity_id",
+                    "description": "Entity_id van de afstandsbediening, meestal een HVAC-apparaat."
+                },
+                "command": {
+                    "name": "Commando",
+                    "description": "Naam van het commando. Eén per opdracht."
+                },
                 "timeout": {
                     "name": "Timeout",
                     "description": "Timeout voor het leren van het commando."

--- a/custom_components/ramses_cc/translations/nl.json
+++ b/custom_components/ramses_cc/translations/nl.json
@@ -234,7 +234,7 @@
                     "description": "De Bericht-code (klasse)."
                 },
                 "payload": {
-                    "name": "Inhoud als HEX",
+                    "name": "Inhoud (HEX)",
                     "description": "De inhoud (`payload`) als hexadecimale string."
                 }
             }
@@ -285,30 +285,52 @@
             "fields": {
                 "entity_id": {
                     "name": "Zone",
-                    "description": "De entity_id van de evohome Zone. NB: in Ramses RF zijn sommige klimaat-entiteiten geen zones (zij zullen een `AttributeError` geven)."
+                    "description": "Entity_id van de evohome Zone. NB: in Ramses RF zijn sommige klimaat-entiteiten geen zones (zij zullen een `AttributeError` geven)."
                 }
             }
         },
 
         "put_zone_temp": {
             "name": "Imiteer sensortemperatuur van een Zone",
-            "description": "Niet mee gebruikt. Gebruik `fake_zone_temp` of `put_room_temp`."
+            "description": "Niet mee gebruikt. Gebruik `fake_zone_temp` of `put_room_temp`.",
+            "fields": {
+                "entity_id": {
+                    "name": "Zone",
+                    "description": "Entity_id van de evohome Zone. NB: in Ramses RF zijn sommige klimaat-entiteiten geen zones (zij zullen een `AttributeError` geven)."
+                }
+            }
         },
 
         "reset_zone_config": {
             "name": "Reset Configuratie van een Zone",
-            "description": "Reset de configuratie van de zone."
+            "description": "Reset de configuratie van de zone.",
+            "fields": {
+                "entity_id": {
+                    "name": "Zone",
+                    "description": "Entity_id van de evohome Zone. NB: in Ramses RF zijn sommige klimaat-entiteiten geen zones (zij zullen een `AttributeError` geven)."
+                }
+            }
         },
 
         "reset_zone_mode": {
             "name": "Reset Modus van een Zone",
-            "description": "Reset de werkmodus van de zone."
+            "description": "Reset de werkmodus van de zone.",
+            "fields": {
+                "entity_id": {
+                    "name": "Zone",
+                    "description": "Entity_id van de evohome Zone. NB: in Ramses RF zijn sommige klimaat-entiteiten geen zones (zij zullen een `AttributeError` geven)."
+                }
+            }
         },
 
         "set_zone_config": {
             "name": "Stel Configuratie van een Zone in",
             "description": "Stel de configuratie van de zone in als:",
             "fields": {
+                "entity_id": {
+                    "name": "Zone",
+                    "description": "Entity_id van de evohome Zone. NB: in Ramses RF zijn sommige klimaat-entiteiten geen zones (zij zullen een `AttributeError` geven)."
+                },
                 "min_temp": {
                     "name": "Minimum",
                     "description": "Het laagst mogelijke instelpunt in graden Celsius (5-21 °C)."
@@ -324,6 +346,10 @@
             "name": "Stel Modus van een Zone in",
             "description": "Stel de werkmodus van de zone in, permanent of voor een bepaalde periode.",
             "fields": {
+                "entity_id": {
+                    "name": "Zone",
+                    "description": "Entity_id van de evohome Zone. NB: in Ramses RF zijn sommige klimaat-entiteiten geen zones (zij zullen een `AttributeError` geven)."
+                },
                 "mode": {
                     "name": "Zone-modus",
                     "description": "Hoe lang is de aanpassing geldig? Kies uit: `follow_schedule`, `advanced_override` (tot vlg. geplande instelling), `temporary_override` (vul hiervoor ook de duur of tot-moment in), of `permanent_override` (vanaf nu)."
@@ -347,6 +373,10 @@
             "name": "Stel weekschema van een Zone in",
             "description": "Upload het weekschema voor een zone in JSON formaat.",
             "fields": {
+                "entity_id": {
+                    "name": "Zone",
+                    "description": "Entity_id van de evohome Zone. NB: in Ramses RF zijn sommige klimaat-entiteiten geen zones (zij zullen een `AttributeError` geven)."
+                },
                 "schedule": {
                     "name": "Weekschema",
                     "description": "Nieuw weekschema voor een zone, in JSON format."
@@ -359,31 +389,53 @@
             "description": "Leest het laatste weekschema van een warmtapwaterapparaat op en werkt met die data de device-status bij. Het weekschema is op te vragen als:: `{{ state_attr('water_heater.stored_hw', 'schedule') }}`",
             "fields": {
                 "entity_id": {
-                    "name": "Opgeslagen DHW",
-                    "description": "Entity_id van de opgeslagen DHW."
+                    "name": "Warmtapwater",
+                    "description": "Entity_id van het Warmtapwaterapparaat."
                 }
             }
         },
 
         "reset_dhw_mode": {
             "name": "Reset Modus Warmtapwater",
-            "description": "Reset de werkmodus van een warmtapwaterapparaat."
+            "description": "Reset de werkmodus van een warmtapwaterapparaat.",
+            "fields": {
+                "entity_id": {
+                    "name": "Warmtapwater",
+                    "description": "Entity_id van het Warmtapwaterapparaat."
+                }
+            }
         },
 
         "reset_dhw_params": {
             "name": "Reset de Configuratie Warmtapwater",
-            "description": "Reset the configuratie van een warmtapwaterapparaat."
+            "description": "Reset the configuratie van een warmtapwaterapparaat.",
+            "fields": {
+                "entity_id": {
+                    "name": "Warmtapwater",
+                    "description": "Entity_id van het Warmtapwaterapparaat."
+                }
+            }
         },
 
         "set_dhw_boost": {
             "name": "Boost Warmtapwater",
-            "description": "Activeer een warmtapwaterapparaat voor 1 uur."
+            "description": "Activeer een warmtapwaterapparaat voor 1 uur.",
+            "fields": {
+                "entity_id": {
+                    "name": "Warmtapwater",
+                    "description": "Entity_id van het Warmtapwaterapparaat."
+                }
+            }
         },
 
         "set_dhw_mode": {
             "name": "Stel Modus voor Warmtapwater in",
             "description": "Stel de werkmodus van een warmtapwaterapparaat in, optioneel voor een bepaalde tijd.",
             "fields": {
+                "entity_id": {
+                    "name": "Warmtapwater",
+                    "description": "Entity_id van het Warmtapwaterapparaat."
+                },
                 "mode": {
                     "name": "Warmwater-modus",
                     "description": "Hoe lang is de aanpassing geldig? Kies uit: `follow_schedule`, `advanced_override` (tot vlg. geplande instelling), `temporary_override` (vul hiervoor ook de duur of tot-moment in), of `permanent_override` (vanaf nu)."
@@ -407,6 +459,10 @@
             "name": "Stel Configuratie van Warmtapwater in",
             "description": "Instellingen voor warmtapwater-apparaat.",
             "fields": {
+                "entity_id": {
+                    "name": "Warmtapwater",
+                    "description": "Entity_id van het Warmtapwaterapparaat."
+                },
                 "setpoint": {
                     "name": "Instelpunt",
                     "description": "Doeltemperatuur in ˚C. Standaardwaarde is 50.0"
@@ -426,6 +482,10 @@
             "name": "Stel weekschema Warmtapwater in",
             "description": "Upload het weekschema voor Warmtapwaterverwarming in JSON formaat.",
             "fields": {
+                "entity_id": {
+                    "name": "Warmtapwater",
+                    "description": "Entity_id van het Warmtapwaterapparaat."
+                },
                 "schedule": {
                     "name": "Weekschema",
                     "description": "Nieuw weekschema voor Warmtapwaterverwarming, in JSON-formaat."
@@ -449,7 +509,7 @@
         },
 
         "fake_dhw_temp": {
-            "name": "Simuleer warmtapwater-temperatuur",
+            "name": "Pas warmtapwater-temperatuur aan",
             "description": "Stel een nieuwe watertemperatuur in (niet het instelpunt) voor een evohome warmtapwaterapparaat. Dit is een makkelijke versie van de `Meld Warmtapwatertemperatuur` actie.",
             "fields": {
                 "entity_id": {
@@ -464,8 +524,8 @@
         },
 
         "put_room_temp": {
-            "name": "Meld Ruimtetemperatuur",
-            "description": "Stel een nieuwe ruimtetemperatuur in (niet het instelpunt) voor een evohome zone thermostaat. De thermostaat moet als `faked` in de `known_list` staan, en als zone-sensor zijn gekoppeld aan een Verwarming/Warmtapwater-controller.",
+            "name": "Pas Ruimtetemperatuur aan",
+            "description": "Stel een nieuwe ruimtetemperatuur in (niet het instelpunt) voor een evohome zone-thermostaat. De thermostaat moet als `faked` in de `known_list` staan, en als zone-sensor zijn gekoppeld aan een Verwarming/Warmtapwater-controller.",
             "fields": {
                 "entity_id": {
                     "name": "Thermostaat",
@@ -479,7 +539,7 @@
         },
 
         "put_dhw_temp": {
-            "name": "Meld Warmtapwatertemperatuur",
+            "name": "Pas Warmtapwatertemperatuur aan",
             "description": "Stel een nieuwe temperatuur in voor een evohome warmwater-sensor. De sensor moet als `faked` in de `known_list` staan, en als warmwater-sensor zijn gekoppeld aan een Verwarming/Warmtapwater-controller.",
             "fields": {
                 "entity_id": {
@@ -494,12 +554,12 @@
         },
 
         "put_co2_level": {
-            "name": "Meld CO2-waarde",
+            "name": "Pas CO2-waarde aan",
             "description": "Stel een nieuwe CO2-waarde in voor een ruimtesensor (experimenteel). De sensor moet als `faked` in de `known_list` staan, en als CO2-sensor zijn gekoppeld aan een fan/ventilatie-eenheid.",
             "fields": {
                 "entity_id": {
                     "name": "Entity_id",
-                    "description": "Entity_id van de sensor. Geeft een foutmelding als de sensor niet `faked` is. Geeft geen foutmelding als hij niet is gekoppeld (maar zal dan niet werken)."
+                    "description": "Entity_id van de CO2-sensor. Geeft een foutmelding als de sensor niet `faked` is. Geeft geen foutmelding als hij niet is gekoppeld (maar zal dan niet werken)."
                 },
                 "co2_level": {
                     "name": "CO2-niveau",
@@ -509,12 +569,12 @@
         },
 
         "put_indoor_humidity": {
-            "name": "Meld Relatieve vochtigheid",
+            "name": "Pas Relatieve vochtigheid aan",
             "description": "Stel een nieuwe waarde in voor de relatieve vochtigheid in een ruimte (experimenteel). De sensor moet als `faked` in de `known_list` staan, en als RV-sensor zijn gekoppeld aan een fan/ventilatie-eenheid.",
             "fields": {
                 "entity_id": {
                     "name": "Entity_id",
-                    "description": "Entity_id van de sensor. Geeft een foutmelding als de sensor niet `faked` is. Geeft geen foutmelding als hij niet is gekoppeld (maar zal dan niet werken)."
+                    "description": "Entity_id van de RV-sensor. Geeft een foutmelding als de sensor niet `faked` is. Geeft geen foutmelding als hij niet is gekoppeld (maar zal dan niet werken)."
                 },
                 "indoor_humidity": {
                     "name": "Relatieve vochtigheid",
@@ -524,7 +584,7 @@
         },
 
         "delete_command": {
-            "name": "Wis commando van een Afstandsbediening",
+            "name": "Wis commando van Afstandsbediening",
             "description": "Verwijdert een RAMSES commando uit de database. Dit is en makkelijke actie voor HA's eigen `delete_command` actie.",
             "fields": {
                 "entity_id": {
@@ -539,7 +599,7 @@
         },
 
         "learn_command": {
-            "name": "Leer een Afstandsbediening-commando",
+            "name": "Leer Afstandsbediening-commando",
             "description": "Vangt een RAMSES commando op en voegt het toe aan de database. Dit is een makkelijke actie voor HA's eigen `learn_command` actie. De afstandsbediening moet als schakelaar al gekoppeld zijn aan een fan/ventilator.",
             "fields": {
                 "timeout": {
@@ -550,7 +610,7 @@
         },
 
         "send_command": {
-            "name": "Verstuur een Remote commando",
+            "name": "Verstuur Afstandsbediening-commando",
             "description": "Verstuurt een RAMSES commando alsof afkomstig van een afstandsbediening. Dit is een makkelijke actie voor HA's eigen `send_command` actie. Het apparaat moet in de `known_list` als `faked` staan en als schakelaar zijn gekoppeld aan een fan/ventilatie-unit.",
             "fields": {
                 "entity_id": {

--- a/custom_components/ramses_cc/translations/nl.json
+++ b/custom_components/ramses_cc/translations/nl.json
@@ -1,11 +1,11 @@
 {
     "config": {
         "abort": {
-            "single_instance_allowed": "Ramses RF is al geconfigureerd. Slechts één configuratie wordt ondersteund."
+            "single_instance_allowed": "Al geconfigureerd. Slechts één configuratie wordt ondersteund."
         },
         "error": {
             "invalid_gateway_config": "Ongeldige ramses_rf configuratie: {error_detail}",
-            "invalid_port_config": "Ongeldige seriële-poortconfiguratie: {error_detail}",
+            "invalid_port_config": "Ongeldige seriële poort-configuratie: {error_detail}",
             "invalid_regex": "Ongeldige reguliere expressie: {error_detail}",
             "invalid_schema": "Ongeldig schema: {error_detail}",
             "invalid_traits": "Ongeldige device-kenmerken: {error_detail}"
@@ -24,18 +24,18 @@
             "choose_serial_port": {
                 "title": "Selecteer de seriële poort",
                 "data": {
-                    "port_name": "Pad naar seriële poort"
+                    "port_name": "Serieel "
                 }
             },
             "configure_serial_port": {
-                "title": "Seriële-poortinstellingen",
+                "title": "Seriële poort-instellingen",
                 "data": {
-                    "port_name": "Pad naar serieel apparaat",
+                    "port_name": "Pad naar serieel device",
                     "serial_port": "Geavanceerde instellingen seriële poort"
                 },
                 "data_description": {
-                    "port_name": "Bijv. '/dev/cu.modem2', 'COM6' (Windows) of 'mqtt://user:pwd@homeassistant.local:1883'",
-                    "serial_port": "Voor standaardgebruik niet vereist."
+                    "port_name": "Bijv. '/dev/cu.modem2' of 'mqtt://user:pwd@homeassistant.local:1883'",
+                    "serial_port": "Normaal niet nodig."
                 }
             },
             "config": {
@@ -45,8 +45,8 @@
                     "ramses_rf": "Geavanceerde instellingen ramses_rf gateway"
                 },
                 "data_description": {
-                    "scan_interval": "Hoe vaak opvragen (pollen) voor wijzigingen? Advies: waarde tussen 60 en 180 s.",
-                    "ramses_rf": "Voor standaardgebruik niet vereist."
+                    "scan_interval": "Hoe vaak pollen voor wijzigingen in toestand? Advies: waarde tussen 60 en 180s.",
+                    "ramses_rf": "Normaal niet nodig."
                 }
             },
             "schema": {
@@ -54,35 +54,35 @@
                 "description": "Zie voor meer info en voorbeelden de [wiki](https://github.com/zxdavb/ramses_cc/wiki/) onder het kopje Configuration.",
                 "data": {
                     "schema": "Systeemschema(s)",
-                    "known_list": "Erkende device_id's",
-                    "enforce_known_list": "Accepteer alleen berichten van erkende device ID's"
+                    "known_list": "Erkende device ID's",
+                    "enforce_known_list": "Accepteer alleen packets van erkende device ID's"
                 },
                 "data_description": {
                     "schema": "Een mapping van systeem device-ID's naar hun schema's. Houd dit eenvoudig en vermeld alleen devices die niet automatisch verschijnen.",
                     "known_list": "Een mapping van erkende device-ID's en (optioneel) hun kenmerken.",
-                    "enforce_known_list": "Aanbevolen om in te schakelen zodra alle device_id's zijn ingevuld,. Het RAMSES II-protocol biedt namelijk geen foutcorrectie en corrupte device_id's komen vaak voor."
+                    "enforce_known_list": "Aanbevolen zodra alle device-ID's zijn ingevuld, omdat het RAMSES II-protocol geen foutcorrectie biedt en corrupte device-ID's vaak voorkomen."
                 }
             },
             "advanced_features": {
                 "title": "Geavanceerde opties",
                 "data": {
-                    "send_packet": "Schakel `send_packet service` in om maatwerkberichten (bytes) te broadcasten",
+                    "send_packet": "Schakel send_packet service in om maatwerkpakketjes te broadcasten",
                     "message_events": "Zend events voor berichten die aan de reguliere expressie voldoen"
                 },
                 "data_description": {
-                    "message_events": "Vul een reguliere expressie in waaraan berichten moeten voldoen, bijv. `RP.* 10:` = events sturen voor alle berichten van een OTB."
+                    "message_events": "Vul een reguliere expressie in waar berichten aan moeten voldoen, bijv. `RP.* 10:` zal events sturen voor alle berichten van een OTB."
                 }
             },
             "packet_log": {
                 "title": "Packet-log",
-                "description": "Optioneel packet-logbestand voor probleemoplossing en doorontwikkeling van de ramses_rf integratie.",
+                "description": "Optioneel packet-log voor oplossen van problemen en ontwikkeling van de integratie.",
                 "data": {
                     "file_name": "Bestandsnaam packet-log",
-                    "rotate_bytes": "Maximumgrootte per packet-log",
+                    "rotate_bytes": "Maximumgrootte van elk packet-log",
                     "rotate_backups": "Aantal te bewaren packet-logs"
                 },
                 "data_description": {
-                    "file_name": "Pad naar het packet-logbestand. Bewaarde backups krijgen deze bestandsnaam + een achtervoegsel."
+                    "file_name": "Pad naar het packet-logbestand. Bewaarde backups gebruiken de bestandsnaam + een achtervoegsel."
                 }
             }
         }
@@ -112,18 +112,18 @@
             "choose_serial_port": {
                 "title": "Selecteer een seriële poort",
                 "data": {
-                    "port_name": "Pad naar serieel apparaat"
+                    "port_name": "Pad naar serieel device"
                 }
             },
             "configure_serial_port": {
-                "title": "Seriële-poortconfiguratie",
+                "title": "Seriële poort-configuratie",
                 "data": {
-                    "port_name": "Pad naar serieel apparaat",
-                    "serial_port": "Geavanceerde seriële-poortconfiguratie"
+                    "port_name": "Pad naar serieel device",
+                    "serial_port": "Geavanceerde seriële poort-configuratie"
                 },
                 "data_description": {
-                    "port_name": "Bijv. '/dev/cu.modem2', 'COM6' of 'mqtt://user:pwd@homeassistant.local:1883'",
-                    "serial_port": "Voor standaardgebruik niet vereist."
+                    "port_name": "Bijv. '/dev/cu.modem2' of 'mqtt://user:pwd@homeassistant.local:1883'",
+                    "serial_port": "Normaal niet nodig."
                 }
             },
             "config": {
@@ -133,17 +133,17 @@
                     "ramses_rf": "Geavanceerde ramses_rf gateway-configuratie"
                 },
                 "data_description": {
-                    "scan_interval": "Hoe vaak opvragen (pollen) voor wijzigingen? Advies: waarde tussen 60 en 180s.",
-                    "ramses_rf": "Voor standaardgebruik niet vereist."
+                    "scan_interval": "Hoe vaak pollen voor wijzigingen in toestand? Advies: waarde tussen 60 en 180s.",
+                    "ramses_rf": "Normaal niet nodig."
                 }
             },
             "schema": {
-                "title": "Systeemschema en erkende apparaten",
+                "title": "Systeemschema en erkende devices",
                 "description": "Zie voor meer info en voorbeelden de [wiki](https://github.com/zxdavb/ramses_cc/wiki/) onder het kopje Configuration.",
                 "data": {
                     "schema": "Systeemschema('s)",
-                    "known_list": "Erkende device_id's",
-                    "enforce_known_list": "Accepteer alleen berichten van erkende device ID's"
+                    "known_list": "Erkende device ID's",
+                    "enforce_known_list": "Accepteer alleen packets van erkende device ID's"
                 },
                 "data_description": {
                     "schema": "Een mapping van systeem device-ID's naar hun schema's. Houd dit eenvoudig en vermeld alleen devices die niet automatisch verschijnen.",
@@ -154,7 +154,7 @@
             "advanced_features": {
                 "title": "Geavanceerde opties",
                 "data": {
-                    "send_packet": "Schakel send_packet service in om maatwerk-berichten te versturen",
+                    "send_packet": "Schakel send_packet service in om maatwerk-packets te zenden",
                     "message_events": "Stuur events voor berichten die voldoen aan een reguliere expressie"
                 },
                 "data_description": {
@@ -162,23 +162,23 @@
                 }
             },
             "packet_log": {
-                "title": "Berichten-logboek",
-                "description": "Optioneel berichten-logbestand voor oplossen van problemen en ontwikkeling van de integratie.",
+                "title": "Packet-log",
+                "description": "Optioneel packet-log voor oplossen van problemen en ontwikkeling van de integratie.",
                 "data": {
-                    "file_name": "Bestandsnaam berichten-logbestanden",
-                    "rotate_bytes": "Maximumgrootte van elk berichten-logbestanden",
-                    "rotate_backups": "Aantal te bewaren berichten-logbestanden"
+                    "file_name": "Bestandsnaam packet-log",
+                    "rotate_bytes": "Maximumgrootte van elk packet-log",
+                    "rotate_backups": "Aantal te bewaren packet-logs"
                 },
                 "data_description": {
-                    "file_name": "Pad naar het berichten-logbestand. Bewaarde backups gebruiken deze naam + een achtervoegsel."
+                    "file_name": "Pad naar het packet-logbestand. Bewaarde backups gebruiken de bestandsnaam + een achtervoegsel."
                 }
             },
             "clear_cache": {
                 "title": "Cache beheren",
-                "description": "De geselecteerde caches worden direct gewist als je op [VERZENDEN] klikt. Herlaad daarna de integratie na grote aanpassingen in het systeemschema of de configuratie. Beide schuifjes naar links = niets wissen",
+                "description": "Selecteer hieronder welke caches direct gewist moeten worden en herlaad dan de integratie bij grote veranderingen in het systeemschema of de configuratie.",
                 "data": {
                     "clear_schema": "Wis ontdekte systeemschema('s)",
-                    "clear_packets": "Wis systeemtoestand (recente berichten)"
+                    "clear_packets": "Wis systeemtoestand (recente packets)"
                 }
             }
         }


### PR DESCRIPTION
- Moved default `en` strings from `services.yaml` to `/translations/en.json`
- Added Dutch translations for all services
- Kept some `name:` values as comments for code readability
- Moved worded `unit_of_measurement` to the description string (e.g. `minutes`), because i18n them is not supported. Leaves room on mobile screen too