### PR TITLE
Config_flow Clear Cache tweak

### DIFF
--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -571,8 +571,8 @@ class RamsesOptionsFlow(BaseRamsesFlow, OptionsFlow):
             return self.async_abort(reason="cache_cleared")
 
         data_schema = {
-            vol.Required("clear_schema", default=True): selector.BooleanSelector(),
-            vol.Required("clear_packets", default=True): selector.BooleanSelector(),
+            vol.Required("clear_schema", default=False): selector.BooleanSelector(),
+            vol.Required("clear_packets", default=False): selector.BooleanSelector(),
         }
 
         return self.async_show_form(


### PR DESCRIPTION
After using the Clear Caches option myself and being confused how to set it in the UI, propose to change default for both switches to False, because the instruction reads: `Choose items below to immediately clear the cache...` and currently - even if I "choose" (meaning change) nothing - both caches are deleted.